### PR TITLE
fix: wrong type in sample model prediction

### DIFF
--- a/examples-go/test-model/main.go
+++ b/examples-go/test-model/main.go
@@ -54,7 +54,7 @@ func main() {
 			err = predictStream.Send(&modelPB.PredictModelRequest{
 				Name:    "ensemble",
 				Version: 1,
-				Type:    0,
+				Type:    1,
 				Content: buf[:n],
 			})
 			firstChunk = false


### PR DESCRIPTION
Because

- When make a prediction request, the user needs to specify CV Task such as classification, object detection. Sample model yolov4 is detection Task

This commit

- type=1 for detection Task (note: type=0 for classification task)
