### PR TITLE
fix: add name in update model api

### DIFF
--- a/examples-go/deploy-model/main.go
+++ b/examples-go/deploy-model/main.go
@@ -85,9 +85,10 @@ func main() {
 
 	_, err = c.UpdateModel(ctx, &modelPB.UpdateModelRequest{
 		Model: &modelPB.UpdateModelInfo{
+			Name:   "ensemble",
 			Status: modelPB.UpdateModelInfo_ONLINE,
 		},
-		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"status"}},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "status"}},
 	})
 	if err != nil {
 		log.Fatal("can not make model online: %v", err)


### PR DESCRIPTION
Because

- Model name is required in UpdateModel method to know which model is updated

This commit

- Add name in UpdateModel request
