### PR TITLE
chore: update model protobuf

### DIFF
--- a/examples-go/deploy-model/main.go
+++ b/examples-go/deploy-model/main.go
@@ -25,7 +25,7 @@ func main() {
 		log.Fatal("the model name is missing, you need to specify the model name for creating pipeline")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, *serverAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -67,6 +67,8 @@ func main() {
 				Optimized:   false,
 				Visibility:  "public",
 				Content:     buf[:n],
+				CvTask:      modelPB.CVTask_DETECTION,
+				Version:     1,
 			})
 			if err != nil {
 				log.Fatalf("failed to send data via stream: %v", err)

--- a/examples-go/test-model/main.go
+++ b/examples-go/test-model/main.go
@@ -25,7 +25,7 @@ func main() {
 		log.Fatal("the model name is missing, you need to specify the model name for creating pipeline")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, *serverAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/bochengyang/zapadapter v0.0.0-20220121170652-8b0c7573d884
 	github.com/go-redis/redis/v8 v8.11.4
-	github.com/instill-ai/protogen-go v0.0.0-20220215054940-36f2370961ef
+	github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b
 	github.com/knadh/koanf v1.4.0
 	go.temporal.io/api v1.7.0
 	go.temporal.io/sdk v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/instill-ai/protogen-go v0.0.0-20220215054940-36f2370961ef h1:PP1ePPnUHyLJhTzmO442ADOSjGUdx/ll0VwlCuQmqYw=
 github.com/instill-ai/protogen-go v0.0.0-20220215054940-36f2370961ef/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b h1:47xsn68li0+CuT38qQR/f2hEeLxxoipkDCnAtJKXLUc=
+github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=


### PR DESCRIPTION
Because

- Model protobuf have updated with CV Task and Version in CreateModel method

This commit

- Add CV Task and Version when CreateModel method
- Increase timeout for uploading/predicting model in examples-go
