### PR TITLE
docs: add redoc that supports multiple openapi spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL:=help
 
 INSTILL_SERVICES := vdp pipeline_backend_migrate pipeline_backend model_backend_migrate model_backend
-3RD_PARTY_SERVICES := triton_server pg_sql cassandra temporal temporal_admin_tools temporal_web redis
+3RD_PARTY_SERVICES := triton_server pg_sql cassandra temporal temporal_admin_tools temporal_web redis redoc
 ALL_SERVICES := ${INSTILL_SERVICES} ${3RD_PARTY_SERVICES}
 
 #============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,3 +175,12 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:
       - 6379:6379
+
+  redoc:
+    container_name: instill-doc
+    image: volbrene/redoc:1.2.0
+    environment:
+      - 'URLS=[{url: ''https://raw.githubusercontent.com/instill-ai/pipeline-backend/main/openapis/pipeline.swagger.json'', name: ''Pipeline''},{url: ''https://raw.githubusercontent.com/instill-ai/model-backend/main/openapis/model.swagger.json'', name: ''Model''}]'
+      - PAGE_TITLE=Instill Doc
+    ports:
+      - 3000:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,10 +177,10 @@ services:
       - 6379:6379
 
   redoc:
-    container_name: instill-doc
+    container_name: openapi
     image: volbrene/redoc:1.2.0
     environment:
       - 'URLS=[{url: ''https://raw.githubusercontent.com/instill-ai/protobufs/main/pipeline/pipeline.swagger.json'', name: ''Pipeline''},{url: ''https://raw.githubusercontent.com/instill-ai/protobufs/main/model/model.swagger.json'', name: ''Model''}]'
-      - PAGE_TITLE=Instill Doc
+      - PAGE_TITLE=Instill AI - API Reference
     ports:
       - 3000:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
     container_name: instill-doc
     image: volbrene/redoc:1.2.0
     environment:
-      - 'URLS=[{url: ''https://raw.githubusercontent.com/instill-ai/pipeline-backend/main/openapis/pipeline.swagger.json'', name: ''Pipeline''},{url: ''https://raw.githubusercontent.com/instill-ai/model-backend/main/openapis/model.swagger.json'', name: ''Model''}]'
+      - 'URLS=[{url: ''https://raw.githubusercontent.com/instill-ai/protobufs/main/pipeline/pipeline.swagger.json'', name: ''Pipeline''},{url: ''https://raw.githubusercontent.com/instill-ai/protobufs/main/model/model.swagger.json'', name: ''Model''}]'
       - PAGE_TITLE=Instill Doc
     ports:
       - 3000:80


### PR DESCRIPTION
Because

- we need to have a document page for REST endpoints

This commit

- add redoc that supports multiple openapi spec.
