### PR TITLE
ci: add semantic PR config

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title AND all the commits
+titleAndCommits: true


### PR DESCRIPTION
Because

- we've adopted conventional commits for both PR and commit title.

This commit

- add [Semantic PR](https://github.com/apps/semantic-pull-requests) configuration file
