### PR TITLE
chore(temporal): use postgres as temporal's storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,19 +129,16 @@ services:
       timeout: 5s
       retries: 6
 
-  cassandra:
-    container_name: cassandra
-    image: cassandra:3.11.11
-    restart: unless-stopped
-    ports:
-      - 9042:9042
-
   temporal:
     container_name: temporal
-    image: temporalio/auto-setup:1.14.2
+    image: temporalio/auto-setup:1.15.0
     restart: unless-stopped
     environment:
-      - CASSANDRA_SEEDS=cassandra
+      - DB=postgresql
+      - DB_PORT=5432
+      - POSTGRES_USER=postgres
+      - POSTGRES_PWD=password
+      - POSTGRES_SEEDS=pg_sql
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
     ports:
       - 7233:7233
@@ -152,7 +149,7 @@ services:
 
   temporal_admin_tools:
     container_name: temporal-admin-tools
-    image: temporalio/admin-tools:1.14.2
+    image: temporalio/admin-tools:1.15.0
     restart: unless-stopped
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,6 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/instill-ai/protogen-go v0.0.0-20220215054940-36f2370961ef h1:PP1ePPnUHyLJhTzmO442ADOSjGUdx/ll0VwlCuQmqYw=
-github.com/instill-ai/protogen-go v0.0.0-20220215054940-36f2370961ef/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b h1:47xsn68li0+CuT38qQR/f2hEeLxxoipkDCnAtJKXLUc=
 github.com/instill-ai/protogen-go v0.0.0-20220216035831-2d9577e0f42b/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=


### PR DESCRIPTION
Because

- we have an existing PostgreSQL running, then we can remove Cassandra as Temporal's storage for resource-saving point of view

This commit

- remove Cassandra
- change configuration in temporal
- correct go.sum
