### PR TITLE
fix(docker-compose): change correct dependency for temporal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
     volumes:
       - ./backends/temporal/dynamicconfig:/etc/temporal/config/dynamicconfig
     depends_on:
-      - cassandra
+      - pg_sql
 
   temporal_admin_tools:
     container_name: temporal-admin-tools


### PR DESCRIPTION
Because

- Temporal now need the dependency of PostgreSQL not Cassandra

This commit

- change correct dependency for temporal
