### PR TITLE
fix(model): update model backend without specify version when creating model

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ mkdir conda-pack
 curl -o conda-pack/python-3-8.tar.gz https://artifacts.instill.tech/vdp/conda-pack/python-3-8.tar.gz
 
 git clone https://github.com/instill-ai/vdp.git
-make
+make all
 ```
 
 ### Run the samples to trigger an object detection pipeline
@@ -80,7 +80,7 @@ curl -o dog.jpg https://artifacts.instill.tech/dog.jpg
 go run deploy-model/main.go --model-path yolov4-onnx-cpu.zip --model-name yolov4
 
 # Test the model
-go run test-model/main.go --model-name yolov4 --test-image dog.jpg
+go run test-model/main.go --model-name yolov4 --model-version 1 --test-image dog.jpg
 
 # Create an object detection pipeline
 go run create-pipeline/main.go --pipeline-name hello-pipeline --model-name yolov4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
   model_backend_migrate:
     container_name: model-backend-migrate
-    image: instill/model-backend:0.1.0
+    image: instill/model-backend:latest
     restart: on-failure
     environment:
       CFG_DATABASE_USERNAME: postgres
@@ -38,7 +38,7 @@ services:
 
   model_backend:
     container_name: model-backend
-    image: instill/model-backend:0.1.0
+    image: instill/model-backend:latest
     restart: unless-stopped
     environment:
       CFG_DATABASE_USERNAME: postgres
@@ -93,7 +93,7 @@ services:
 
   triton_server:
     container_name: triton-server
-    image: nvcr.io/nvidia/tritonserver:21.09-py3
+    image: nvcr.io/nvidia/tritonserver:22.01-py3
     restart: unless-stopped
     command: tritonserver --model-store=/model-repository --model-control-mode=explicit --allow-http=true --strict-model-config=false
     ports:

--- a/examples-go/deploy-model/main.go
+++ b/examples-go/deploy-model/main.go
@@ -66,7 +66,6 @@ func main() {
 				Description: "YoloV4 for object detection",
 				CvTask:      modelPB.CVTask_DETECTION,
 				Content:     buf[:n],
-				Version:     int32(*modelVersion),
 			})
 			if err != nil {
 				log.Fatalf("failed to send data via stream: %v", err)
@@ -100,8 +99,9 @@ func main() {
 
 	_, err = c.UpdateModel(ctx, &modelPB.UpdateModelRequest{
 		Model: &modelPB.UpdateModelInfo{
-			Name:   *modelName,
-			Status: modelPB.ModelStatus_ONLINE,
+			Name:    *modelName,
+			Status:  modelPB.ModelStatus_ONLINE,
+			Version: int32(*modelVersion),
 		},
 		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "status"}},
 	})

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/bochengyang/zapadapter v0.0.0-20220121170652-8b0c7573d884
 	github.com/go-redis/redis/v8 v8.11.4
-	github.com/instill-ai/protogen-go v0.0.0-20220218052108-74a473c326b7
+	github.com/instill-ai/protogen-go v0.0.0-20220219063332-5b8ade9e4923
 	github.com/knadh/koanf v1.4.0
 	go.temporal.io/api v1.7.0
 	go.temporal.io/sdk v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,10 @@ github.com/instill-ai/protogen-go v0.0.0-20220217181519-50f173dd2ca4 h1:QCIW6nwZ
 github.com/instill-ai/protogen-go v0.0.0-20220217181519-50f173dd2ca4/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/instill-ai/protogen-go v0.0.0-20220218052108-74a473c326b7 h1:G0gFscf9E6lWlJmMsIkaqEM1uGWee/49GWN9O4i0pCo=
 github.com/instill-ai/protogen-go v0.0.0-20220218052108-74a473c326b7/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.0.0-20220219062322-6a4b524722dc h1:FB/LZrD1T12txnLqmg4Dta2GzC399O27/Nkiyd22nRA=
+github.com/instill-ai/protogen-go v0.0.0-20220219062322-6a4b524722dc/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.0.0-20220219063332-5b8ade9e4923 h1:Mczqp333gw3aiIzjdh8ZunOaRs1ROIKCN1t3nG9H6Bo=
+github.com/instill-ai/protogen-go v0.0.0-20220219063332-5b8ade9e4923/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=


### PR DESCRIPTION
Because

- To make the model API convenient to users, the model version should be auto increased

This commit

- Update model backend which auto increase model version when user create a model with an existed name
- Update example corresponding with the latest model protobuf
- Fix a small typo in README
