### PR TITLE
ci: use container for conda-pack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL:=help
 
-INSTILL_SERVICES := vdp pipeline_backend_migrate pipeline_backend model_backend_migrate model_backend
-3RD_PARTY_SERVICES := triton_server pg_sql cassandra temporal temporal_admin_tools temporal_web redis redoc_openapi
+INSTILL_SERVICES := vdp pipeline_backend_migrate pipeline_backend model_backend_migrate model_backend triton_conda_env
+3RD_PARTY_SERVICES := triton_server pg_sql temporal temporal_admin_tools temporal_web redis redoc_openapi
 ALL_SERVICES := ${INSTILL_SERVICES} ${3RD_PARTY_SERVICES}
 
 #============================================================================
@@ -13,15 +13,15 @@ export
 #============================================================================
 
 all:			## Build and launch all services
-	@docker-compose up -d
+	@docker-compose up -d ${ALL_SERVICES}
 .PHONY: all
 
 logs:			## Tail all logs with -n 10
-	@docker-compose logs --follow --tail=10
+	@docker-compose logs --follow --tail=10 ${ALL_SERVICES}
 .PHONY: logs
 
 pull:			## Pull all images
-	@docker-compose pull
+	@docker-compose pull ${ALL_SERVICES}
 .PHONY: pull
 
 stop:			## Stop all components
@@ -41,7 +41,7 @@ rm:				## Remove all stopped service containers
 .PHONY: rm
 
 down:			## Stop all services and remove all service containers
-	@docker-compose down
+	@docker-compose down ${ALL_SERVICES}
 .PHONY: down
 
 images:			## List all container images

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ networks:
     name: instill-network
 
 volumes:
+  conda_pack:
+    name: conda-pack
   model_repository:
     name: model-repository
   pg_sql:
@@ -91,6 +93,12 @@ services:
       - temporal
       - redis
 
+  triton_conda_env:
+    container_name: triton-conda-env
+    image: instill/triton-conda-env:v0.1.0-alpha-cpu
+    volumes:
+      - conda_pack:/conda-pack
+
   triton_server:
     container_name: triton-server
     image: nvcr.io/nvidia/tritonserver:22.01-py3
@@ -100,7 +108,7 @@ services:
       - 8001:8001
     volumes:
       - model_repository:/model-repository
-      - ./conda-pack:/conda-pack
+      - conda_pack:/conda-pack
     healthcheck:
       test: ["CMD-SHELL", "curl localhost:8000/v2/health/ready"]
       timeout: 20s
@@ -109,6 +117,8 @@ services:
     ulimits:
         memlock: -1
         stack: 67108864
+    depends_on:
+      - triton_conda_env
 
   pg_sql:
     container_name: pg-sql


### PR DESCRIPTION
Because

- we'd like the official conda-pack to be loaded by the Triton server without the user intervening. 

This commit

- use the triton-conda-env CPU container to leverage the shared volume to load conda-pack into the Triton container
- update Makefile accordingly
