### PR TITLE
docs: add api reference section and remove conda-pack downloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ build:			## Build local docker image
 	@DOCKER_BUILDKIT=1 docker build -t instill/vdp:latest .
 .PHONY: build
 
+doc:			## Run Redoc for OpenAPI spec at http://localhost:3000
+	@docker-compose up -d redoc_openapi
+.PHONY: doc
+
 help:       	## Show this help
 	@echo "\nMake Application using Docker-Compose files."
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m (default: help)\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ go run trigger-pipeline/main.go --pipeline-name hello-pipeline --test-image dog.
 ```
 
 ### Create a pipeline with your own model
-Please follow the guideline on [How to prepare your own model to deploy on VDP](docs/model.md#prepare-your-own-model-to-deploy-on-vdp). Then, use the sample codes above to deploy the prepared model and create your own pipeline.
+Please follow the guideline "[Prepare your own model to deploy on VDP
+](docs/model.md#prepare-your-own-model-to-deploy-on-vdp)." Based on the above sample codes, you can deploy a prepared model and create your own pipeline.
 
 ### Clean up
 To clean up all running services:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ go run trigger-pipeline/main.go --pipeline-name hello-pipeline --test-image dog.
 Please follow the guideline on [How to prepare your own model to deploy on VDP](docs/model.md#prepare-your-own-model-to-deploy-on-vdp). Then, use the sample codes above to deploy the prepared model and create your own pipeline.
 
 ### Clean up
-Execute the following command to clean up all running services
+To clean up all running services:
 ```
 make prune
 ```

--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ Execute the following commands to start pre-built images with all the dependenci
 ```bash
 git clone https://github.com/instill-ai/vdp.git
 
-mkdir conda-pack
-curl -o conda-pack/python-3-8.tar.gz https://artifacts.instill.tech/vdp/conda-pack/python-3-8.tar.gz
-
 make all
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,12 +99,11 @@ make prune
 
 ## Documentation
 
-The gRPC protocols in [protobufs](https://github.com/instill-ai/protobufs) provide the single source of truth for the VDP APIs. To view the generated OpenAPI spec:
+The gRPC protocols in [protobufs](https://github.com/instill-ai/protobufs) provide the single source of truth for the VDP APIs. To view the generated OpenAPI spec, run
 ```bash
-make all
+make doc
 ```
-Now visit http://localhost:3000
-
+, and now visit http://localhost:3000.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ git clone https://github.com/instill-ai/vdp.git
 
 make all
 ```
-Note that it may take a long time due to the size of the Triton server image.
+Note that this may take a while due to the big size of the Triton server image.
 
 ### Run the samples to trigger an object detection pipeline
 We provide sample codes on how to build and trigger an object detection pipeline. Run it with the local VDP.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ For general help using VDP, you can use one of these channels:
 
 ### API reference
 
+The gRPC protocols in [protobufs](https://github.com/instill-ai/protobufs) provide the single source of truth for the VDP APIs. To view the generated OpenAPI spec:
+```bash
+make all
+```
+Now visit http://localhost:3000
+
+
 ### Build docker
 
 You can build a development Docker image using:

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ The goal of VDP is to seamlessly bring Vision AI into modern data stack with a s
   - [Download and run VDP locally](#download-and-run-vdp-locally)
   - [Run the samples to trigger an object detection pipeline](#run-the-samples-to-trigger-an-object-detection-pipeline)
   - [Create a pipeline with your own model](#create-a-pipeline-with-your-own-model)
-- [Community support](#community-support)
+  - [Clean up](#clean-up)
 - [Documentation](#documentation)
-  - [API reference](#api-reference)
-  - [Build docker](#build-docker)
+- [Development](#development)
+- [Community support](#community-support)
 - [License](#license)
 
 > Code in the main branch tracks under-development progress towards the next release and may not work as expected. If you are looking for a stable version, please use [latest release](https://github.com/instill-ai/vdp/releases).
@@ -90,16 +90,13 @@ go run trigger-pipeline/main.go --pipeline-name hello-pipeline --test-image dog.
 ### Create a pipeline with your own model
 Please follow the guideline on [How to prepare your own model to deploy on VDP](docs/model.md#prepare-your-own-model-to-deploy-on-vdp). Then, use the sample codes above to deploy the prepared model and create your own pipeline.
 
-## Community support
-
-For general help using VDP, you can use one of these channels:
-
-- [GitHub](https://github.com/instill-ai/vdp) (bug reports, feature requests, project discussions and contributions)
-- [Discord](https://discord.gg/sevxWsqpGh) (live discussion with the community and the Instill AI Team)
+### Clean up
+Execute the following command to clean up all running services
+```
+make prune
+```
 
 ## Documentation
-
-### API reference
 
 The gRPC protocols in [protobufs](https://github.com/instill-ai/protobufs) provide the single source of truth for the VDP APIs. To view the generated OpenAPI spec:
 ```bash
@@ -108,12 +105,19 @@ make all
 Now visit http://localhost:3000
 
 
-### Build docker
+## Development
 
 You can build a development Docker image using:
 ```bash
 make build
 ```
+
+## Community support
+
+For general help using VDP, you can use one of these channels:
+
+- [GitHub](https://github.com/instill-ai/vdp) (bug reports, feature requests, project discussions and contributions)
+- [Discord](https://discord.gg/sevxWsqpGh) (live discussion with the community and the Instill AI Team)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ make all
 Now visit http://localhost:3000
 
 
-## Development
+## Local development
 
 You can build a development Docker image using:
 ```bash

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ go run create-pipeline/main.go --pipeline-name hello-pipeline --model-name yolov
 go run trigger-pipeline/main.go --pipeline-name hello-pipeline --test-image dog.jpg
 ```
 
-### Create a pipeline with your own model
+### Create a pipeline with your own models
 Please follow the guideline "[Prepare your own model to deploy on VDP
 ](docs/model.md#prepare-your-own-model-to-deploy-on-vdp)." Based on the above sample codes, you can deploy a prepared model and create your own pipeline.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The goal of VDP is to seamlessly bring Vision AI into modern data stack with a s
   - [Build docker](#build-docker)
 - [License](#license)
 
+> Code in the main branch tracks under-development progress towards the next release and may not work as expected. If you are looking for a stable version, please use [latest release](https://github.com/instill-ai/vdp/releases).
+
 ## How VDP works
 
 The core concept of VDP is _pipeline_. A pipeline is an end-to-end workflow that automates end-to-end visual data processing. Each pipeline consists of three ordered components:

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ The goal of VDP is to seamlessly bring Vision AI into modern data stack with a s
 - [Quick start](#quick-start)
   - [Download and run VDP locally](#download-and-run-vdp-locally)
   - [Run the samples to trigger an object detection pipeline](#run-the-samples-to-trigger-an-object-detection-pipeline)
-  - [Create a pipeline with your own model](#create-a-pipeline-with-your-own-model)
+  - [Create a pipeline with your own models](#create-a-pipeline-with-your-own-models)
   - [Clean up](#clean-up)
 - [Documentation](#documentation)
-- [Development](#development)
+- [Local development](#local-development)
 - [Community support](#community-support)
 - [License](#license)
 
@@ -53,7 +53,7 @@ We use **data connector** as a general term to represent data source and data de
 
 ### Download and run VDP locally
 
-Execute the following commands to start pre-built images with all the dependencies
+Execute the following commands to start pre-built images with all the dependencies:
 
 ```bash
 git clone https://github.com/instill-ai/vdp.git
@@ -63,7 +63,7 @@ make all
 Note that this may take a while due to the big size of the Triton server image.
 
 ### Run the samples to trigger an object detection pipeline
-We provide sample codes on how to build and trigger an object detection pipeline. Run it with the local VDP.
+We provide sample codes on how to build and trigger an object detection pipeline. Run it with the local VDP:
 
 ```bash
 cd examples-go

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ git clone https://github.com/instill-ai/vdp.git
 
 make all
 ```
+Note that it may take a long time due to the size of the Triton server image.
 
 ### Run the samples to trigger an object detection pipeline
 We provide sample codes on how to build and trigger an object detection pipeline. Run it with the local VDP.


### PR DESCRIPTION
Because

- API reference section is empty

This commit

- add API reference
- add `make doc` for launching Redoc at https://localhost:3000
- add warning for `main` branch: codebase is under-development
- remove conda-pack downloading from quick start
- add warning for long docker image pulling time
- change the section order
- add clean up section in quick start