### PR TITLE
ci: add codecov action

### DIFF
--- a/.github/workflows/add-issue-to-prj.yml
+++ b/.github/workflows/add-issue-to-prj.yml
@@ -1,4 +1,4 @@
-name: Add Issue to project
+name: Add Issue to Project
 
 on:
   issues:

--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -1,4 +1,4 @@
-name: Add PR to project
+name: Add PR to Project
 
 on:
   pull_request:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+name: Coverage
+
+on: [push, pull_request]
+
+jobs:
+
+  codecov:
+    name: codecov
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.17
+
+      - uses: actions/checkout@v2
+
+      - name: Generate coverage report
+        run: |
+          go test -race ./... -coverprofile=coverage.txt -covermode=atomic
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage.txt
+          flags: unittests
+          name: codecov-umbrella


### PR DESCRIPTION
Because

- we would like to regularly check test coverage of the codebase

This commit

- set up codecov action
- make GitHub Actions workflow name consistent
