### PR TITLE
refactor(model): update model with the updated protobuf

### DIFF
--- a/examples-go/create-pipeline/main.go
+++ b/examples-go/create-pipeline/main.go
@@ -46,7 +46,7 @@ func main() {
 			Models: []*pb.Model{
 				{
 					Name:    *modelName,
-					Version: int32(*modelVersion),
+					Version: uint64(*modelVersion),
 				},
 			},
 			Destination: &pb.Destination{Type: "Direct"},

--- a/examples-go/create-pipeline/main.go
+++ b/examples-go/create-pipeline/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	pb "github.com/instill-ai/protogen-go/pipeline"
+	pb "github.com/instill-ai/protogen-go/pipeline/v1alpha"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -35,7 +35,7 @@ func main() {
 	}
 	defer conn.Close()
 
-	client := pb.NewPipelineClient(conn)
+	client := pb.NewPipelineServiceClient(conn)
 
 	createPipelineReq := &pb.CreatePipelineRequest{
 		Name:        *pipelineName,
@@ -43,7 +43,7 @@ func main() {
 		Active:      true,
 		Recipe: &pb.Recipe{
 			Source: &pb.Source{Type: "Direct"},
-			Model: []*pb.Model{
+			Models: []*pb.Model{
 				{
 					Name:    *modelName,
 					Version: int32(*modelVersion),

--- a/examples-go/deploy-model/main.go
+++ b/examples-go/deploy-model/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	modelPB "github.com/instill-ai/protogen-go/model"
+	modelPB "github.com/instill-ai/protogen-go/model/v1alpha"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -35,9 +35,9 @@ func main() {
 	}
 	defer conn.Close()
 
-	c := modelPB.NewModelClient(conn)
+	c := modelPB.NewModelServiceClient(conn)
 
-	uploadStream, err := c.CreateModelByUpload(ctx)
+	uploadStream, err := c.CreateModelBinaryFileUpload(ctx)
 	if err != nil {
 		log.Fatalf("can not create model: %v", err)
 	}
@@ -61,19 +61,23 @@ func main() {
 			log.Fatalf("there is an error while copying from file to buf: %v", err)
 		}
 		if firstChunk {
-			err = uploadStream.Send(&modelPB.CreateModelRequest{
-				Name:        *modelName,
-				Description: "YoloV4 for object detection",
-				CvTask:      modelPB.CVTask_DETECTION,
-				Content:     buf[:n],
+			err = uploadStream.Send(&modelPB.CreateModelBinaryFileUploadRequest{
+				ModelInitData: &modelPB.ModelInitData{
+					Name:        *modelName,
+					Description: "YoloV4 for object detection",
+					Task:        modelPB.Model_TASK_DETECTION,
+					Byte:        buf[:n],
+				},
 			})
 			if err != nil {
 				log.Fatalf("failed to send data via stream: %v", err)
 			}
 			firstChunk = false
 		} else {
-			err = uploadStream.Send(&modelPB.CreateModelRequest{
-				Content: buf[:n],
+			err = uploadStream.Send(&modelPB.CreateModelBinaryFileUploadRequest{
+				ModelInitData: &modelPB.ModelInitData{
+					Byte: buf[:n],
+				},
 			})
 			if err != nil {
 				log.Fatalf("failed to send data via stream: %v", err)
@@ -92,18 +96,18 @@ func main() {
 		model, err := c.GetModel(ctx, &modelPB.GetModelRequest{
 			Name: *modelName,
 		})
-		if err == nil && model.Name != "" {
+		if err == nil && model.Model.Name != "" {
 			break
 		}
 	}
 
-	_, err = c.UpdateModel(ctx, &modelPB.UpdateModelRequest{
+	_, err = c.UpdateModelVersion(ctx, &modelPB.UpdateModelVersionRequest{
 		Name:    *modelName,
-		Version: int32(*modelVersion),
-		Model: &modelPB.UpdateModelInfo{
-			Status: modelPB.ModelStatus_ONLINE,
+		Version: uint64(*modelVersion),
+		VersionPatch: &modelPB.UpdateModelVersionPatch{
+			Status: modelPB.ModelVersion_STATUS_ONLINE,
 		},
-		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "status"}},
+		FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "status"}},
 	})
 	if err != nil {
 		log.Fatalf("can not make model online: %v", err)

--- a/examples-go/deploy-model/main.go
+++ b/examples-go/deploy-model/main.go
@@ -62,12 +62,10 @@ func main() {
 		}
 		if firstChunk {
 			err = uploadStream.Send(&modelPB.CreateModelBinaryFileUploadRequest{
-				ModelInitData: &modelPB.ModelInitData{
-					Name:        *modelName,
-					Description: "YoloV4 for object detection",
-					Task:        modelPB.Model_TASK_DETECTION,
-					Byte:        buf[:n],
-				},
+				Name:        *modelName,
+				Description: "YoloV4 for object detection",
+				Task:        modelPB.Model_TASK_DETECTION,
+				Bytes:       buf[:n],
 			})
 			if err != nil {
 				log.Fatalf("failed to send data via stream: %v", err)
@@ -75,9 +73,7 @@ func main() {
 			firstChunk = false
 		} else {
 			err = uploadStream.Send(&modelPB.CreateModelBinaryFileUploadRequest{
-				ModelInitData: &modelPB.ModelInitData{
-					Byte: buf[:n],
-				},
+				Bytes: buf[:n],
 			})
 			if err != nil {
 				log.Fatalf("failed to send data via stream: %v", err)

--- a/examples-go/test-model/main.go
+++ b/examples-go/test-model/main.go
@@ -64,7 +64,7 @@ func main() {
 			err = predictStream.Send(&modelPB.TriggerModelBinaryFileUploadRequest{
 				Name:    *modelName,
 				Version: uint64(*modelVersion),
-				Chunk:   buf[:n],
+				Bytes:   buf[:n],
 			})
 			if err != nil {
 				log.Fatalf("failed to send data via stream: %v", err)
@@ -72,7 +72,7 @@ func main() {
 			firstChunk = false
 		} else {
 			err = predictStream.Send(&modelPB.TriggerModelBinaryFileUploadRequest{
-				Chunk: buf[:n],
+				Bytes: buf[:n],
 			})
 			if err != nil {
 				log.Fatalf("failed to send data via stream: %v", err)

--- a/examples-go/test-model/main.go
+++ b/examples-go/test-model/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	modelPB "github.com/instill-ai/protogen-go/model"
+	modelPB "github.com/instill-ai/protogen-go/model/v1alpha"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -35,9 +35,9 @@ func main() {
 	}
 	defer conn.Close()
 
-	c := modelPB.NewModelClient(conn)
+	c := modelPB.NewModelServiceClient(conn)
 
-	predictStream, err := c.PredictModelByUpload(ctx)
+	predictStream, err := c.TriggerModelBinaryFileUpload(ctx)
 	if err != nil {
 		log.Fatalf("can not test model via predict endpoint: %v", err)
 	}
@@ -61,18 +61,18 @@ func main() {
 			log.Fatalf("there is an error while copying from file to buf: %s", errRead.Error())
 		}
 		if firstChunk {
-			err = predictStream.Send(&modelPB.PredictModelRequest{
+			err = predictStream.Send(&modelPB.TriggerModelBinaryFileUploadRequest{
 				Name:    *modelName,
-				Version: int32(*modelVersion),
-				Content: buf[:n],
+				Version: uint64(*modelVersion),
+				Chunk:   buf[:n],
 			})
 			if err != nil {
 				log.Fatalf("failed to send data via stream: %v", err)
 			}
 			firstChunk = false
 		} else {
-			err = predictStream.Send(&modelPB.PredictModelRequest{
-				Content: buf[:n],
+			err = predictStream.Send(&modelPB.TriggerModelBinaryFileUploadRequest{
+				Chunk: buf[:n],
 			})
 			if err != nil {
 				log.Fatalf("failed to send data via stream: %v", err)

--- a/examples-go/trigger-pipeline/main.go
+++ b/examples-go/trigger-pipeline/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	pb "github.com/instill-ai/protogen-go/pipeline"
+	pb "github.com/instill-ai/protogen-go/pipeline/v1alpha"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -34,7 +34,7 @@ func main() {
 	}
 	defer conn.Close()
 
-	client := pb.NewPipelineClient(conn)
+	client := pb.NewPipelineServiceClient(conn)
 
 	file, err := os.Open(*testIamgePath)
 	if err != nil {
@@ -42,12 +42,12 @@ func main() {
 	}
 	defer file.Close()
 
-	stream, err := client.TriggerPipelineByUpload(ctx)
+	stream, err := client.TriggerPipelineBinaryFileUpload(ctx)
 	if err != nil {
 		log.Fatal("cannot upload image: ", err)
 	}
 
-	req := &pb.TriggerPipelineImageRequest{
+	req := &pb.TriggerPipelineBinaryFileUploadRequest{
 		Name: *pipelineName,
 	}
 
@@ -68,12 +68,7 @@ func main() {
 			log.Fatal("cannot read chunk to buffer: ", err)
 		}
 
-		contents := []*pb.TriggerPipelineImageContent{}
-		contents = append(contents, &pb.TriggerPipelineImageContent{Chunk: buffer[:n]})
-
-		req := &pb.TriggerPipelineImageRequest{
-			Contents: contents,
-		}
+		req := &pb.TriggerPipelineBinaryFileUploadRequest{Chunk: buffer[:n]}
 
 		err = stream.Send(req)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/bochengyang/zapadapter v0.0.0-20220121170652-8b0c7573d884
 	github.com/go-redis/redis/v8 v8.11.4
-	github.com/instill-ai/protogen-go v0.1.3-alpha
+	github.com/instill-ai/protogen-go v0.1.4-alpha
 	github.com/knadh/koanf v1.4.0
 	go.temporal.io/api v1.7.0
 	go.temporal.io/sdk v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/bochengyang/zapadapter v0.0.0-20220121170652-8b0c7573d884
 	github.com/go-redis/redis/v8 v8.11.4
-	github.com/instill-ai/protogen-go v0.1.1-alpha
+	github.com/instill-ai/protogen-go v0.1.3-alpha
 	github.com/knadh/koanf v1.4.0
 	go.temporal.io/api v1.7.0
 	go.temporal.io/sdk v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/instill-ai/protogen-go v0.1.1-alpha h1:rZ/mGWOi8sbSfub840WBDB/AmaClgk
 github.com/instill-ai/protogen-go v0.1.1-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/instill-ai/protogen-go v0.1.3-alpha h1:h0WVkztKB/+urFneyesWaRHa/LdTJAazT2xCwK6hrnw=
 github.com/instill-ai/protogen-go v0.1.3-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.1.4-alpha h1:Je7QW9/4S1nWgAGwEtEZb0cUl0n/Fbilp/bkl99KN2o=
+github.com/instill-ai/protogen-go v0.1.4-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/instill-ai/protogen-go v0.1.1-alpha h1:rZ/mGWOi8sbSfub840WBDB/AmaClgkRjGT/8sDvCveo=
 github.com/instill-ai/protogen-go v0.1.1-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.1.3-alpha h1:h0WVkztKB/+urFneyesWaRHa/LdTJAazT2xCwK6hrnw=
+github.com/instill-ai/protogen-go v0.1.3-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/pkg/temporal/activities.go
+++ b/pkg/temporal/activities.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/instill-ai/protogen-go/pipeline"
+	pipeline "github.com/instill-ai/protogen-go/pipeline/v1alpha"
 	"github.com/instill-ai/vdp/configs"
 	"github.com/instill-ai/vdp/internal/cache"
 	"github.com/instill-ai/vdp/pkg/models"

--- a/tests/integration-tests/model-backend-rest.js
+++ b/tests/integration-tests/model-backend-rest.js
@@ -54,15 +54,15 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models/upload (multipart) task cls response Status": (r) =>
+        "POST /models/upload (multipart) task cls response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task cls response Name": (r) =>
+          "POST /models/upload (multipart) task cls response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          "POST /models/upload (multipart) task cls response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task cls response task": (r) =>
+          "POST /models/upload (multipart) task cls response model.task": (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
-          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          "POST /models/upload (multipart) task cls response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
 
@@ -75,15 +75,15 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_det.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_det.boundary}`),
       }), {
-        "POST /models/upload (multipart) task det response Status": (r) =>
+        "POST /models/upload (multipart) task det response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task det response Name": (r) =>
+          "POST /models/upload (multipart) task det response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task det response FullName": (r) =>
+          "POST /models/upload (multipart) task det response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task det response task": (r) =>
+          "POST /models/upload (multipart) task det response model.task": (r) =>
           r.json().model.task === "TASK_DETECTION",
-          "POST /models/upload (multipart) task det response Versions": (r) =>
+          "POST /models/upload (multipart) task det response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
 
@@ -95,15 +95,15 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_undefined.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_undefined.boundary}`),
       }), {
-        "POST /models/upload (multipart) task undefined response Status": (r) =>
+        "POST /models/upload (multipart) task undefined response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task undefined response Name": (r) =>
+          "POST /models/upload (multipart) task undefined response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task undefined response FullName": (r) =>
+          "POST /models/upload (multipart) task undefined response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task undefined response task": (r) =>
+          "POST /models/upload (multipart) task undefined response model.task": (r) =>
           r.json().model.task === undefined, //default value of TASK_UNSPECIFIED task is 0 which not in response
-          "POST /models/upload (multipart) task undefined response Versions": (r) =>
+          "POST /models/upload (multipart) task undefined response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
 
@@ -111,19 +111,19 @@ export default function (data) {
       check(http.request("DELETE", `${apiHost}/models/${model_name_cls}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
       check(http.request("DELETE", `${apiHost}/models/${model_name_det}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
       check(http.request("DELETE", `${apiHost}/models/${model_name_unspecified}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
     });
@@ -141,15 +141,15 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models/upload (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task cls response Name": (r) =>
+          "POST /models/upload (multipart) task cls response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          "POST /models/upload (multipart) task cls response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task cls response task": (r) =>
+          "POST /models/upload (multipart) task cls response model.task": (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
-          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          "POST /models/upload (multipart) task cls response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
 
@@ -161,15 +161,15 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_det.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_det.boundary}`),
       }), {
-        "POST /models/upload (multipart) det response Status": (r) =>
+        "POST /models/upload (multipart) det response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task det response Name": (r) =>
+          "POST /models/upload (multipart) task det response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task det response FullName": (r) =>
+          "POST /models/upload (multipart) task det response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task det response task": (r) =>
+          "POST /models/upload (multipart) task det response model.task": (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
-          "POST /models/upload (multipart) task det response Versions": (r) =>
+          "POST /models/upload (multipart) task det response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 2,
       });
 
@@ -180,15 +180,15 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_undefined.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_undefined.boundary}`),
       }), {
-        "POST /models/upload (multipart) undefined response Status": (r) =>
+        "POST /models/upload (multipart) undefined response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task undefined response Name": (r) =>
+          "POST /models/upload (multipart) task undefined response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task undefined response FullName": (r) =>
+          "POST /models/upload (multipart) task undefined response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task undefined response task": (r) =>
+          "POST /models/upload (multipart) task undefined response model.task": (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
-          "POST /models/upload (multipart) task undefined response Versions": (r) =>
+          "POST /models/upload (multipart) task undefined response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 3,
       });
 
@@ -196,7 +196,7 @@ export default function (data) {
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
     });
@@ -215,29 +215,29 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models/upload (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task cls response Name": (r) =>
+          "POST /models/upload (multipart) task cls response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          "POST /models/upload (multipart) task cls response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task cls response task": (r) =>
+          "POST /models/upload (multipart) task cls response model.task": (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
-          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          "POST /models/upload (multipart) task cls response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models/upload (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task cls response Name": (r) =>
+          "POST /models/upload (multipart) task cls response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          "POST /models/upload (multipart) task cls response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task cls response task": (r) =>
+          "POST /models/upload (multipart) task cls response model.task": (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
-          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          "POST /models/upload (multipart) task cls response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 2,
       });
 
@@ -247,19 +247,19 @@ export default function (data) {
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH /models/${model_name}/versions/1 online task cls response Status`]: (r) =>
+        [`PATCH /models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH /models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.version`]: (r) =>
           r.json().modelVersion.version !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.modelId`]: (r) =>
           r.json().modelVersion.modelId !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.description`]: (r) =>
           r.json().modelVersion.description !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.createdAt`]: (r) =>
           r.json().modelVersion.createdAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.updatedAt`]: (r) =>
           r.json().modelVersion.updatedAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response model version modelVersion.status`]: (r) =>
           r.json().modelVersion.status === "STATUS_ONLINE",
       });
 
@@ -271,17 +271,17 @@ export default function (data) {
       }), {
         [`PATCH /models/${model_name}/versions/2 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH /models/${model_name}/versions/2 online task cls response version`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response modelVersion.version`]: (r) =>
           r.json().modelVersion.version !== undefined,
-          [`PATCH /models/${model_name}/versions/2 online task cls response model_id`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response modelVersion.modelId`]: (r) =>
           r.json().modelVersion.modelId !== undefined,
-          [`PATCH /models/${model_name}/versions/2 online task cls response description`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response modelVersion.description`]: (r) =>
           r.json().modelVersion.description !== undefined,
-          [`PATCH /models/${model_name}/versions/2 online task cls response created_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response modelVersion.createdAt`]: (r) =>
           r.json().modelVersion.createdAt !== undefined,
-          [`PATCH /models/${model_name}/versions/2 online task cls response updated_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response modelVersion.updatedAt`]: (r) =>
           r.json().modelVersion.updatedAt !== undefined,
-          [`PATCH /models/${model_name}/versions/2 online task cls response model version status`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response model version modelVersion.status`]: (r) =>
           r.json().modelVersion.status === "STATUS_ONLINE",
       });
 
@@ -293,17 +293,17 @@ export default function (data) {
       }), {
         [`PATCH /models/${model_name}/versions/1 offline task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH /models/${model_name}/versions/1 offline task cls response Version`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 offline task cls response modelVersion.version`]: (r) =>
           r.json().modelVersion.version !== undefined,
-          [`PATCH /models/${model_name}/versions/1 offline task cls response model_id`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 offline task cls response modelVersion.modelId`]: (r) =>
           r.json().modelVersion.modelId !== undefined,
-          [`PATCH /models/${model_name}/versions/1 offline task cls response description`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 offline task cls response modelVersion.description`]: (r) =>
           r.json().modelVersion.description !== undefined,
-          [`PATCH /models/${model_name}/versions/1 offline task cls response created_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 offline task cls response modelVersion.createdAt`]: (r) =>
           r.json().modelVersion.createdAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 offline task cls response updated_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 offline task cls response modelVersion.updatedAt`]: (r) =>
           r.json().modelVersion.updatedAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 offline task cls response model version status`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 offline task cls response model version modelVersion.status`]: (r) =>
           r.json().modelVersion.status === "STATUS_OFFLINE",
       });
 
@@ -318,17 +318,17 @@ export default function (data) {
       }), {
         [`PATCH /models/${model_name}/versions/2 offline task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH /models/${model_name}/versions/2 offline task cls response Version`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 offline task cls response modelVersion.version`]: (r) =>
           r.json().modelVersion.version !== undefined,
-          [`PATCH /models/${model_name}/versions/2 offline task cls response model_id`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 offline task cls response modelVersion.modelId`]: (r) =>
           r.json().modelVersion.modelId !== undefined,
-          [`PATCH /models/${model_name}/versions/2 offline task cls response description`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 offline task cls response modelVersion.description`]: (r) =>
           r.json().modelVersion.description !== undefined,
-          [`PATCH /models/${model_name}/versions/2 offline task cls response created_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 offline task cls response modelVersion.createdAt`]: (r) =>
           r.json().modelVersion.createdAt !== undefined,
-          [`PATCH /models/${model_name}/versions/2 offline task cls response updated_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 offline task cls response modelVersion.updatedAt`]: (r) =>
           r.json().modelVersion.updatedAt !== undefined,
-          [`PATCH /models/${model_name}/versions/2 offline task cls response model version status`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 offline task cls response model version modelVersion.status`]: (r) =>
           r.json().modelVersion.status === "STATUS_OFFLINE",
       });
 
@@ -336,7 +336,7 @@ export default function (data) {
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
 
@@ -358,15 +358,15 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models/upload (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task cls response Name": (r) =>
+          "POST /models/upload (multipart) task cls response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          "POST /models/upload (multipart) task cls response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task cls response task": (r) =>
+          "POST /models/upload (multipart) task cls response model.task": (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
-          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          "POST /models/upload (multipart) task cls response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
 
@@ -378,17 +378,17 @@ export default function (data) {
       }), {
         [`PATCH /models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH /models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.version`]: (r) =>
           r.json().modelVersion.version !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.modelId`]: (r) =>
           r.json().modelVersion.modelId !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.description`]: (r) =>
           r.json().modelVersion.description !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.createdAt`]: (r) =>
           r.json().modelVersion.createdAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.updatedAt`]: (r) =>
           r.json().modelVersion.updatedAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response model version modelVersion.status`]: (r) =>
           r.json().modelVersion.status === "STATUS_ONLINE",
       });
 
@@ -399,7 +399,7 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST /models/${model_name}/versions/1/outputs url cls response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs url cls response status`]: (r) =>
           r.status === 200,
           [`POST /models/${model_name}/versions/1/outputs url cls contents`]: (r) =>
           r.json().output.classificationOutputs.length === 1,
@@ -416,7 +416,7 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST /models/${model_name}/versions/1/outputs base64 cls response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs base64 cls response status`]: (r) =>
           r.status === 200,
           [`POST /models/${model_name}/versions/1/outputs base64 cls contents`]: (r) =>
           r.json().output.classificationOutputs.length === 1,
@@ -432,7 +432,7 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/upload/outputs`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
-        [`POST /models/${model_name}/versions/1/upload/outputs form-data cls response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/upload/outputs form-data cls response status`]: (r) =>
           r.status === 200,
           [`POST /models/${model_name}/versions/1/upload/outputs form-data cls contents`]: (r) =>
           r.json().output.classificationOutputs.length === 1,
@@ -446,7 +446,7 @@ export default function (data) {
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
 
@@ -468,15 +468,15 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models/upload (multipart) det response Status": (r) =>
+        "POST /models/upload (multipart) det response status": (r) =>
           r.status === 200,
-          "POST /models/upload (multipart) task det response Name": (r) =>
+          "POST /models/upload (multipart) task det response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task det response FullName": (r) =>
+          "POST /models/upload (multipart) task det response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task det response task": (r) =>
+          "POST /models/upload (multipart) task det response model.task": (r) =>
           r.json().model.task === "TASK_DETECTION",
-          "POST /models/upload (multipart) task det response Versions": (r) =>
+          "POST /models/upload (multipart) task det response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
 
@@ -488,17 +488,17 @@ export default function (data) {
       }), {
         [`PATCH /models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH /models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.version`]: (r) =>
           r.json().modelVersion.version !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.modelId`]: (r) =>
           r.json().modelVersion.modelId !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.description`]: (r) =>
           r.json().modelVersion.description !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.createdAt`]: (r) =>
           r.json().modelVersion.createdAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.updatedAt`]: (r) =>
           r.json().modelVersion.updatedAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response model version modelVersion.status`]: (r) =>
           r.json().modelVersion.status === "STATUS_ONLINE",
       });
 
@@ -509,15 +509,15 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST /models/${model_name}/versions/1/outputs url det response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs url det response status`]: (r) =>
           r.status === 200,
-          [`POST /models/${model_name}/versions/1/outputs url det contents`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs url det output.detectionOutput.length`]: (r) =>
           r.json().output.detectionOutput.length === 1,
-          [`POST /models/${model_name}/versions/1/outputs url det response category`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs url det response output.detectionOutput[0].boundingBoxObjects[0].category`]: (r) =>
           r.json().output.detectionOutput[0].boundingBoxObjects[0].category === "test",
-          [`POST /models/${model_name}/versions/1/outputs url det response score`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs url det response output.detectionOutput[0].boundingBoxObjects[0].score`]: (r) =>
           r.json().output.detectionOutput[0].boundingBoxObjects[0].score !== undefined,
-          [`POST /models/${model_name}/versions/1/outputs url det response bounding_box`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs url det response output.detectionOutput[0].boundingBoxObjects[0].boundingBox`]: (r) =>
           r.json().output.detectionOutput[0].boundingBoxObjects[0].boundingBox !== undefined,
       });
 
@@ -528,15 +528,15 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST /models/${model_name}/versions/1/outputs base64 det response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs base64 det response status`]: (r) =>
           r.status === 200,
-          [`POST /models/${model_name}/versions/1/outputs base64 det contents`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs base64 det output.detectionOutput.length`]: (r) =>
           r.json().output.detectionOutput.length === 1,
-          [`POST /models/${model_name}/versions/1/outputs base64 det response category`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs base64 det response output.detectionOutput[0].boundingBoxObjects[0].category`]: (r) =>
           r.json().output.detectionOutput[0].boundingBoxObjects[0].category === "test",
-          [`POST /models/${model_name}/versions/1/outputs base64 det response score`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs base64 det response output.detectionOutput[0].boundingBoxObjects[0].score`]: (r) =>
           r.json().output.detectionOutput[0].boundingBoxObjects[0].score !== undefined,
-          [`POST /models/${model_name}/versions/1/outputs base64 det response bounding_box`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs base64 det response output.detectionOutput[0].boundingBoxObjects[0].boundingBox`]: (r) =>
           r.json().output.detectionOutput[0].boundingBoxObjects[0].boundingBox !== undefined,
       });
 
@@ -546,15 +546,15 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/upload/outputs`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
-        [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response status`]: (r) =>
           r.status === 200,
-          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det contents`]: (r) =>
+          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det output.detectionOutput[0].boundingBoxObjects.length`]: (r) =>
           r.json().output.detectionOutput[0].boundingBoxObjects.length === 1,
-          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response category`]: (r) =>
+          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response output.detectionOutput[0].boundingBoxObjects[0].category`]: (r) =>
           r.json().output.detectionOutput[0].boundingBoxObjects[0].category === "test",
-          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response score`]: (r) =>
+          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response output.detectionOutput[0].boundingBoxObjects[0].score`]: (r) =>
           r.json().output.detectionOutput[0].boundingBoxObjects[0].score !== undefined,
-          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response bounding_box`]: (r) =>
+          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response output.detectionOutput[0].boundingBoxObjects[0].boundingBox`]: (r) =>
           r.json().output.detectionOutput[0].boundingBoxObjects[0].boundingBox !== undefined,
       });
 
@@ -562,7 +562,7 @@ export default function (data) {
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
 
@@ -583,15 +583,15 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
-        "POST /models/upload (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task cls response Name": (r) =>
+          "POST /models/upload (multipart) task cls response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          "POST /models/upload (multipart) task cls response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task cls response task": (r) =>
+          "POST /models/upload (multipart) task cls response model.task": (r) =>
           r.json().model.task === undefined,
-          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          "POST /models/upload (multipart) task cls response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
 
@@ -603,17 +603,17 @@ export default function (data) {
       }), {
         [`PATCH /models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH /models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.version`]: (r) =>
           r.json().modelVersion.version !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.modelId`]: (r) =>
           r.json().modelVersion.modelId !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.description`]: (r) =>
           r.json().modelVersion.description !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.createdAt`]: (r) =>
           r.json().modelVersion.createdAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.updatedAt`]: (r) =>
           r.json().modelVersion.updatedAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response model version modelVersion.status`]: (r) =>
           r.json().modelVersion.status === "STATUS_ONLINE",
       });
 
@@ -624,7 +624,7 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST /models/${model_name}/versions/1/outputs url undefined response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs url undefined response status`]: (r) =>
           r.status === 200,
           [`POST /models/${model_name}/versions/1/outputs url undefined outputs`]: (r) =>
           r.json().output.outputs.length === 1,
@@ -643,15 +643,15 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST /models/${model_name}/versions/1/outputs base64 undefined response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs base64 undefined response status`]: (r) =>
           r.status === 200,
-          [`POST /models/${model_name}/versions/1/outputs base64 undefined outputs`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs base64 undefined output.outputs.length`]: (r) =>
           r.json().output.outputs.length === 1,
-          [`POST /models/${model_name}/versions/1/outputs base64 undefined parameters`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs base64 undefined output.parameters`]: (r) =>
           r.json().output.parameters !== undefined,
-          [`POST /models/${model_name}/versions/1/outputs base64 undefined raw_output_contents`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs base64 undefined output.rawOutputContents.length`]: (r) =>
           r.json().output.rawOutputContents.length === 1,
-          [`POST /models/${model_name}/versions/1/outputs base64 undefined raw_output_contents content`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs base64 undefined output.rawOutputContents[0]`]: (r) =>
           r.json().output.rawOutputContents[0] !== undefined,
       });
 
@@ -661,15 +661,15 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/upload/outputs`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
-        [`POST /models/${model_name}/versions/1/outputs multipart undefined response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs multipart undefined response status`]: (r) =>
           r.status === 200,
-          [`POST /models/${model_name}/versions/1/outputs multipart undefined outputs`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs multipart undefined output.outputs.length`]: (r) =>
           r.json().output.outputs.length === 1,
-          [`POST /models/${model_name}/versions/1/outputs multipart undefined parameters`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs multipart undefined output.parameters`]: (r) =>
           r.json().output.parameters !== undefined,
-          [`POST /models/${model_name}/versions/1/outputs multipart undefined raw_output_contents`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs multipart undefined output.raw_output_contents.length`]: (r) =>
           r.json().output.rawOutputContents.length === 1,
-          [`POST /models/${model_name}/versions/1/outputs multipart undefined raw_output_contents content`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs multipart undefined output.rawOutputContents[0]`]: (r) =>
           r.json().output.rawOutputContents[0] !== undefined,
       });
 
@@ -677,7 +677,7 @@ export default function (data) {
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
 
@@ -699,35 +699,35 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models/upload (multipart) det response Status": (r) =>
+        "POST /models/upload (multipart) det response status": (r) =>
           r.status === 200,
-          "POST /models/upload (multipart) task det response Name": (r) =>
+          "POST /models/upload (multipart) task det response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task det response FullName": (r) =>
+          "POST /models/upload (multipart) task det response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task det response task": (r) =>
+          "POST /models/upload (multipart) task det response model.task": (r) =>
           r.json().model.task === "TASK_DETECTION",
-          "POST /models/upload (multipart) task det response Versions": (r) =>
+          "POST /models/upload (multipart) task det response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
       check(http.get(`${apiHost}/models/${model_name}`, {
         headers: genHeader(`application/json`),
       }), {
-        [`GET /models/${model_name} response Status`]: (r) =>
+        [`GET /models/${model_name} response status`]: (r) =>
           r.status === 200,
           [`GET /models/${model_name} task`]: (r) =>
           r.json().model.task === "TASK_DETECTION",
-          [`GET /models/${model_name} versions`]: (r) =>
+          [`GET /models/${model_name} model.modelVersions.length`]: (r) =>
           r.json().model.modelVersions.length === 1,
-          [`GET /models/${model_name} version created_at`]: (r) =>
+          [`GET /models/${model_name} version model.modelVersions[0].createdAt`]: (r) =>
           r.json().model.modelVersions[0].createdAt !== undefined,
-          [`GET /models/${model_name} version updated_at`]: (r) =>
+          [`GET /models/${model_name} version model.modelVersions[0].updatedAt`]: (r) =>
           r.json().model.modelVersions[0].updatedAt !== undefined,
-          [`GET /models/${model_name} version status`]: (r) =>
+          [`GET /models/${model_name} version model.modelVersions[0].status`]: (r) =>
           r.json().model.modelVersions[0].status === "STATUS_OFFLINE",
-          [`GET /models/${model_name} id`]: (r) =>
+          [`GET /models/${model_name} model.id`]: (r) =>
           r.json().model.id !== undefined,
-          [`GET /models/${model_name} full_Name`]: (r) =>
+          [`GET /models/${model_name} model.fullName`]: (r) =>
           r.json().model.fullName === `local-user/${model_name}`,
       });
 
@@ -735,7 +735,7 @@ export default function (data) {
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
 
@@ -757,36 +757,36 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models/upload (multipart) det response Status": (r) =>
+        "POST /models/upload (multipart) det response status": (r) =>
           r.status === 200,
-          "POST /models/upload (multipart) task det response Name": (r) =>
+          "POST /models/upload (multipart) task det response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task det response FullName": (r) =>
+          "POST /models/upload (multipart) task det response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task det response task": (r) =>
+          "POST /models/upload (multipart) task det response model.task": (r) =>
           r.json().model.task === "TASK_DETECTION",
-          "POST /models/upload (multipart) task det response Versions": (r) =>
+          "POST /models/upload (multipart) task det response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
 
       check(http.get(`${apiHost}/models`, {
         headers: genHeader(`application/json`),
       }), {
-        [`GET /models response Status`]: (r) =>
+        [`GET /models response status`]: (r) =>
           r.status === 200,
           [`GET /models task`]: (r) =>
           r.json().models[0].task !== undefined,
-          [`GET /models versions`]: (r) =>
+          [`GET /models models[0].modelVersions.length`]: (r) =>
           r.json().models[0].modelVersions.length > 0,
-          [`GET /models version created_at`]: (r) =>
+          [`GET /models models[0].modelVersions[0].createdAt`]: (r) =>
           r.json().models[0].modelVersions[0].createdAt !== undefined,
-          [`GET /models version updated_at`]: (r) =>
+          [`GET /models models[0].modelVersions[0].updatedAt`]: (r) =>
           r.json().models[0].modelVersions[0].updatedAt !== undefined,
-          [`GET /models version status`]: (r) =>
+          [`GET /models models[0].modelVersions[0].status`]: (r) =>
           r.json().models[0].modelVersions[0].status !== undefined,
-          [`GET /models id`]: (r) =>
+          [`GET /models models[0].id`]: (r) =>
           r.json().models[0].id !== undefined,
-          [`GET /models full_Name`]: (r) =>
+          [`GET /models models[0].fullName`]: (r) =>
           r.json().models[0].fullName !== undefined,
       });
 
@@ -794,7 +794,7 @@ export default function (data) {
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
 
@@ -816,30 +816,30 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models/upload (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task cls response Name": (r) =>
+          "POST /models (multipart) task cls response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          "POST /models/upload (multipart) task cls response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task cls response task": (r) =>
+          "POST /models/upload (multipart) task cls response model.task": (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
-          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          "POST /models/upload (multipart) task cls response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 1,
       });
 
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models (multipart) cls response Status": (r) =>
+        "POST /models (multipart) cls response status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models/upload (multipart) task cls response Name": (r) =>
+          "POST /models/upload (multipart) task cls response model.name": (r) =>
           r.json().model.name !== undefined,
-          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          "POST /models/upload (multipart) task cls response model.fullName": (r) =>
           r.json().model.fullName !== undefined,
-          "POST /models/upload (multipart) task cls response task": (r) =>
+          "POST /models/upload (multipart) task cls response model.task": (r) =>
           r.json().model.task === "TASK_CLASSIFICATION",
-          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          "POST /models/upload (multipart) task cls response model.modelVersions.length": (r) =>
           r.json().model.modelVersions.length === 2,
       });
 
@@ -852,17 +852,17 @@ export default function (data) {
       }), {
         [`PATCH /models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH /models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.version`]: (r) =>
           r.json().modelVersion.version !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.modelId`]: (r) =>
           r.json().modelVersion.modelId !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.description`]: (r) =>
           r.json().modelVersion.description === new_description,
-          [`PATCH /models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.createdAt`]: (r) =>
           r.json().modelVersion.createdAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response modelVersion.updatedAt`]: (r) =>
           r.json().modelVersion.updatedAt !== undefined,
-          [`PATCH /models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          [`PATCH /models/${model_name}/versions/1 online task cls response model version modelVersion.status`]: (r) =>
           r.json().modelVersion.status !== undefined,
       });
 
@@ -875,17 +875,17 @@ export default function (data) {
       }), {
         [`PATCH /models/${model_name}/versions/2 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH /models/${model_name}/versions/2 online task cls response version`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response modelVersion.version`]: (r) =>
           r.json().modelVersion.version !== undefined,
-          [`PATCH /models/${model_name}/versions/2 online task cls response model_id`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response modelVersion.modelId`]: (r) =>
           r.json().modelVersion.modelId !== undefined,
-          [`PATCH /models/${model_name}/versions/2 online task cls response description`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response modelVersion.description`]: (r) =>
           r.json().modelVersion.description === new_description2,
-          [`PATCH /models/${model_name}/versions/2 online task cls response created_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response modelVersion.createdAt`]: (r) =>
           r.json().modelVersion.createdAt !== undefined,
-          [`PATCH /models/${model_name}/versions/2 online task cls response updated_at`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response modelVersion.updatedAt`]: (r) =>
           r.json().modelVersion.updatedAt !== undefined,
-          [`PATCH /models/${model_name}/versions/2 online task cls response model version status`]: (r) =>
+          [`PATCH /models/${model_name}/versions/2 online task cls response model version modelVersion.status`]: (r) =>
           r.json().modelVersion.status !== undefined,
       });
 
@@ -893,7 +893,7 @@ export default function (data) {
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
-        "DELETE clean up response Status": (r) =>
+        "DELETE clean up response status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
 

--- a/tests/integration-tests/model-backend-rest.js
+++ b/tests/integration-tests/model-backend-rest.js
@@ -49,44 +49,44 @@ export default function (data) {
       let model_name1 = randomString(10)
       fd_cls.append("name", model_name1);
       fd_cls.append("description", randomString(20));
-      fd_cls.append("cvtask", "CLASSIFICATION");
+      fd_cls.append("task", "TASK_CLASSIFICATION");
       fd_cls.append("content", http.file(cls_model, "dummy-cls-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models (multipart) cvtask cls response Status": (r) =>
+        "POST /models (multipart) task cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask cls response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().CVTask === "CLASSIFICATION",   
-          "POST /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
+          "POST /models (multipart) task cls response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task cls response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task cls response task": (r) =>
+          r.json().Task === "TASK_CLASSIFICATION",
+          "POST /models (multipart) task cls response Versions": (r) =>
+          r.json().Versions.length === 1,
       });
 
       let fd_det = new FormData();
       let model_name2 = randomString(10)
       fd_det.append("name", model_name2);
       fd_det.append("description", randomString(20));
-      fd_det.append("cvtask", "DETECTION");
+      fd_det.append("task", "TASK_DETECTION");
       fd_det.append("content", http.file(cls_model, "dummy-det-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_det.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_det.boundary}`),
       }), {
-        "POST /models (multipart) cvtask det response Status": (r) =>
+        "POST /models (multipart) task det response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask det response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask det response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask det response CVTask": (r) =>
-          r.json().CVTask === "DETECTION",   
-          "POST /models (multipart) cvtask det response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
-      });     
-      
+          "POST /models (multipart) task det response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task det response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task det response task": (r) =>
+          r.json().Task === "TASK_DETECTION",
+          "POST /models (multipart) task det response Versions": (r) =>
+          r.json().Versions.length === 1,
+      });
+
       let fd_undefined = new FormData();
       let model_name3 = randomString(10)
       fd_undefined.append("name", model_name3);
@@ -95,36 +95,36 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_undefined.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_undefined.boundary}`),
       }), {
-        "POST /models (multipart) cvtask undefined response Status": (r) =>
+        "POST /models (multipart) task undefined response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask undefined response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask undefined response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask undefined response CVTask": (r) =>
-          r.json().CVTask === "UNDEFINED",   
-          "POST /models (multipart) cvtask undefined response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
-      });        
+          "POST /models (multipart) task undefined response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task undefined response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task undefined response task": (r) =>
+          r.json().Task === "TASK_UNSPECIFIED",
+          "POST /models (multipart) task undefined response Versions": (r) =>
+          r.json().Versions.length === 1,
+      });
       // clean up
       check(http.request("DELETE", `${apiHost}/models/${model_name1}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      }); 
+      });
       check(http.request("DELETE", `${apiHost}/models/${model_name2}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      }); 
+      });
       check(http.request("DELETE", `${apiHost}/models/${model_name3}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      }); 
+      });
     });
   }
 
@@ -135,43 +135,43 @@ export default function (data) {
       let model_name = randomString(10)
       fd_cls.append("name", model_name);
       fd_cls.append("description", randomString(20));
-      fd_cls.append("cvtask", "CLASSIFICATION");
+      fd_cls.append("task", "TASK_CLASSIFICATION");
       fd_cls.append("content", http.file(cls_model, "dummy-cls-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
         "POST /models (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask cls response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().CVTask === "CLASSIFICATION",   
-          "POST /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
+          "POST /models (multipart) task cls response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task cls response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task cls response task": (r) =>
+          r.json().Task === "TASK_CLASSIFICATION",
+          "POST /models (multipart) task cls response Versions": (r) =>
+          r.json().Versions.length === 1,
       });
 
       let fd_det = new FormData();
       fd_det.append("name", model_name);
       fd_det.append("description", randomString(20));
-      fd_det.append("cvtask", "DETECTION");
+      fd_det.append("task", "TASK_DETECTION");
       fd_det.append("content", http.file(cls_model, "dummy-det-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_det.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_det.boundary}`),
       }), {
         "POST /models (multipart) det response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask det response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask det response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask det response CVTask": (r) =>
-          r.json().CVTask === "CLASSIFICATION",   
-          "POST /models (multipart) cvtask det response Versions": (r) =>
-          r.json().Versions.length === 2,                                        
-      });     
-      
+          "POST /models (multipart) task det response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task det response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task det response task": (r) =>
+          r.json().Task === "TASK_CLASSIFICATION",
+          "POST /models (multipart) task det response Versions": (r) =>
+          r.json().Versions.length === 2,
+      });
+
       let fd_undefined = new FormData();
       fd_undefined.append("name", model_name);
       fd_undefined.append("description", randomString(20));
@@ -181,22 +181,22 @@ export default function (data) {
       }), {
         "POST /models (multipart) undefined response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask undefined response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask undefined response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask undefined response CVTask": (r) =>
-          r.json().CVTask === "CLASSIFICATION",   
-          "POST /models (multipart) cvtask undefined response Versions": (r) =>
-          r.json().Versions.length === 3,                                        
-      });        
+          "POST /models (multipart) task undefined response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task undefined response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task undefined response task": (r) =>
+          r.json().Task === "TASK_CLASSIFICATION",
+          "POST /models (multipart) task undefined response Versions": (r) =>
+          r.json().Versions.length === 3,
+      });
       // clean up
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      }); 
+      });
     });
   }
 
@@ -208,135 +208,140 @@ export default function (data) {
       console.log("Create model ", model_name)
       fd_cls.append("name", model_name);
       fd_cls.append("description", randomString(20));
-      fd_cls.append("cvtask", "CLASSIFICATION");
+      fd_cls.append("task", "TASK_CLASSIFICATION");
       fd_cls.append("content", http.file(cls_model, "dummy-cls-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
         "POST /models (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask cls response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().CVTask === "CLASSIFICATION",   
-          "POST /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
+          "POST /models (multipart) task cls response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task cls response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task cls response task": (r) =>
+          r.json().Task === "TASK_CLASSIFICATION",
+          "POST /models (multipart) task cls response Versions": (r) =>
+          r.json().Versions.length === 1,
       });
-
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
         "POST /models (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask cls response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().CVTask === "CLASSIFICATION",   
-          "POST /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().Versions.length === 2,                                        
-      });      
+          "POST /models (multipart) task cls response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task cls response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task cls response task": (r) =>
+          r.json().Task === "TASK_CLASSIFICATION",
+          "POST /models (multipart) task cls response Versions": (r) =>
+          r.json().Versions.length === 2,
+      });
 
       let payload = JSON.stringify({
-        "status": 1
+        "status": 2,
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        "PATCH /models (multipart) cls response Status": (r) =>
+        [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response Status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          "PATCH /models (multipart) cvtask cls response Name": (r) =>
-          r.json().name !== undefined,      
-          "PATCH /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().full_Name !== undefined,   
-          "PATCH /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().cv_task === "CLASSIFICATION",   
-          "PATCH /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().versions.length === 2,       
-          "PATCH /models (multipart) cvtask cls response Version 1 Status": (r) =>
-          r.json().versions[0].status === "ONLINE",  
-          "PATCH /models (multipart) cvtask cls response Version 2 Status": (r) =>
-          r.json().versions[1].status === "OFFLINE",                                                            
-      });  
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          r.json().model_version.version !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          r.json().model_version.model_id !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          r.json().model_version.description !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          r.json().model_version.created_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          r.json().model_version.updated_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          r.json().model_version.status === "STATUS_ONLINE",
+      });
 
       payload = JSON.stringify({
-        "status": 1
+        "status": 2,
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/2`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        "PATCH /models (multipart) cls response Status": (r) =>
+        [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          "PATCH /models (multipart) cvtask cls response Name": (r) =>
-          r.json().name !== undefined,      
-          "PATCH /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().full_Name !== undefined,   
-          "PATCH /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().cv_task === "CLASSIFICATION",   
-          "PATCH /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().versions.length === 2,       
-          "PATCH /models (multipart) cvtask cls response Version 1 Status": (r) =>
-          r.json().versions[0].status === "ONLINE",  
-          "PATCH /models (multipart) cvtask cls response Version 2 Status": (r) =>
-          r.json().versions[1].status === "ONLINE",                                                            
-      });    
-      
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response version`]: (r) =>
+          r.json().model_version.version !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response model_id`]: (r) =>
+          r.json().model_version.model_id !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response description`]: (r) =>
+          r.json().model_version.description !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response created_at`]: (r) =>
+          r.json().model_version.created_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response updated_at`]: (r) =>
+          r.json().model_version.updated_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response model version status`]: (r) =>
+          r.json().model_version.status === "STATUS_ONLINE",
+      });
+
       payload = JSON.stringify({
-        "status": 0
+        "status": 1,
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        "PATCH /models (multipart) cls response Status": (r) =>
+        [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          "PATCH /models (multipart) cvtask cls response Name": (r) =>
-          r.json().name !== undefined,      
-          "PATCH /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().full_Name !== undefined,   
-          "PATCH /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().cv_task === "CLASSIFICATION",   
-          "PATCH /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().versions.length === 2,       
-          "PATCH /models (multipart) cvtask cls response Version 1 Status": (r) =>
-          r.json().versions[0].status === "OFFLINE",  
-          "PATCH /models (multipart) cvtask cls response Version 2 Status": (r) =>
-          r.json().versions[1].status === "ONLINE",                                                            
-      });  
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response Version`]: (r) =>
+          r.json().model_version.version !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response model_id`]: (r) =>
+          r.json().model_version.model_id !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response description`]: (r) =>
+          r.json().model_version.description !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response created_at`]: (r) =>
+          r.json().model_version.created_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response updated_at`]: (r) =>
+          r.json().model_version.updated_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response model version status`]: (r) =>
+          r.json().model_version.status === "STATUS_OFFLINE",
+      });
+
+      // Triton unloading models takes time
+      sleep(4)
 
       payload = JSON.stringify({
-        "status": 0
+        "status": 1,
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/2`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        "PATCH /models (multipart) cls response Status": (r) =>
+        [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          "PATCH /models (multipart) cvtask cls response Name": (r) =>
-          r.json().name !== undefined,      
-          "PATCH /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().full_Name !== undefined,   
-          "PATCH /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().cv_task === "CLASSIFICATION",   
-          "PATCH /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().versions.length === 2,       
-          "PATCH /models (multipart) cvtask cls response Version 1 Status": (r) =>
-          r.json().versions[0].status === "OFFLINE",  
-          "PATCH /models (multipart) cvtask cls response Version 2 Status": (r) =>
-          r.json().versions[1].status === "OFFLINE",                                                            
-      });       
-      
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response Version`]: (r) =>
+          r.json().model_version.version !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response model_id`]: (r) =>
+          r.json().model_version.model_id !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response description`]: (r) =>
+          r.json().model_version.description !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response created_at`]: (r) =>
+          r.json().model_version.created_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response updated_at`]: (r) =>
+          r.json().model_version.updated_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response model version status`]: (r) =>
+          r.json().model_version.status === "STATUS_OFFLINE",
+      });
+
       // clean up
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      });   
+      });
+
+      // Triton unloading models takes time
+      sleep(4)
     });
-  }  
+  }
 
   // Model Backend API: make inference
   {
@@ -346,103 +351,108 @@ export default function (data) {
       console.log("Create model ", model_name)
       fd_cls.append("name", model_name);
       fd_cls.append("description", randomString(20));
-      fd_cls.append("cvtask", "CLASSIFICATION");
+      fd_cls.append("task", "TASK_CLASSIFICATION");
       fd_cls.append("content", http.file(cls_model, "dummy-cls-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
         "POST /models (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask cls response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().CVTask === "CLASSIFICATION",   
-          "POST /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
+          "POST /models (multipart) task cls response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task cls response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task cls response task": (r) =>
+          r.json().Task === "TASK_CLASSIFICATION",
+          "POST /models (multipart) task cls response Versions": (r) =>
+          r.json().Versions.length === 1,
       });
 
       let payload = JSON.stringify({
-        "status": 1
+        "status": 2
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        "PATCH /models/ (multipart) cls response Status": (r) =>
+        [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          "PATCH /models (multipart) cvtask cls response Name": (r) =>
-          r.json().name !== undefined,      
-          "PATCH /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().full_Name !== undefined,   
-          "PATCH /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().cv_task === "CLASSIFICATION",   
-          "PATCH /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().versions.length === 1,       
-          "PATCH /models (multipart) cvtask cls response Version 1 Status": (r) =>
-          r.json().versions[0].status === "ONLINE",  
-      });  
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          r.json().model_version.version !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          r.json().model_version.model_id !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          r.json().model_version.description !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          r.json().model_version.created_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          r.json().model_version.updated_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          r.json().model_version.status === "STATUS_ONLINE",
+      });
 
       // Predict with url
       payload = JSON.stringify({
-        "contents": [{"url": "https://artifacts.instill.tech/dog.jpg"}]
+        "inputs": [{"image_url": "https://artifacts.instill.tech/dog.jpg"}]
       });
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
         [`POST ${apiHost}/models/${model_name}/versions/1/outputs url cls response Status`]: (r) =>
-          r.status === 200, 
+          r.status === 200,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs url cls contents`]: (r) =>
-          r.json().contents.length === 1,  
+          r.json().output.classification_outputs.length === 1,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs url cls contents.category`]: (r) =>
-          r.json().contents[0].category === "match",  
+          r.json().output.classification_outputs[0].category === "match",
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs url cls response contents.score`]: (r) =>
-          r.json().contents[0].score === 1,            
-      });  
+          r.json().output.classification_outputs[0].score === 1,
+      });
 
       // Predict with base64
       payload = JSON.stringify({
-        "contents": [{"base64": base64_image,}]
+        "inputs": [{"image_base64": base64_image,}]
       });
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
         [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls response Status`]: (r) =>
-          r.status === 200, 
+          r.status === 200,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls contents`]: (r) =>
-          r.json().contents.length === 1,  
+          r.json().output.classification_outputs.length === 1,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls contents.category`]: (r) =>
-          r.json().contents[0].category === "match",  
+          r.json().output.classification_outputs[0].category === "match",
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls response contents.score`]: (r) =>
-          r.json().contents[0].score === 1,            
-      });  
+          r.json().output.classification_outputs[0].score === 1,
+      });
 
       // Predict with multiple-part
       const fd = new FormData();
-      fd.append("contents", http.file(dog_img));
+      fd.append("inputs", http.file(dog_img));
       check(http.post(`${apiHost}/models/${model_name}/versions/1/upload/outputs`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
-        [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls response Status`]: (r) =>
-          r.status === 200, 
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls contents`]: (r) =>
-          r.json().contents.length === 1,  
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls contents.category`]: (r) =>
-          r.json().contents[0].category === "match",  
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls response contents.score`]: (r) =>
-          r.json().contents[0].score === 1,            
-      });      
-      
+        [`POST ${apiHost}/models/${model_name}/versions/1/outputs form-data cls response Status`]: (r) =>
+          r.status === 200,
+          [`POST ${apiHost}/models/${model_name}/versions/1/outputs form-data cls contents`]: (r) =>
+          r.json().output.classification_outputs.length === 1,
+          [`POST ${apiHost}/models/${model_name}/versions/1/outputs form-data cls contents.category`]: (r) =>
+          r.json().output.classification_outputs[0].category === "match",
+          [`POST ${apiHost}/models/${model_name}/versions/1/outputs form-data cls response contents.score`]: (r) =>
+          r.json().output.classification_outputs[0].score === 1,
+      });
+
       // clean up
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      });   
+      });
+
+      // Triton unloading models takes time
+      sleep(4)
     });
-  }  
-  
+  }
+
   // Model Backend API: make inference
   {
     group("Model Backend API: Predict Model with detection model", function () {
@@ -451,118 +461,117 @@ export default function (data) {
       console.log("Create model ", model_name)
       fd_cls.append("name", model_name);
       fd_cls.append("description", randomString(20));
-      fd_cls.append("cvtask", "DETECTION");
+      fd_cls.append("task", "TASK_DETECTION");
       fd_cls.append("content", http.file(det_model, "dummy-det-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
         "POST /models/upload (multipart) det response Status": (r) =>
-          r.status === 200, 
-          "POST /models/upload (multipart) cvtask det response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models/upload (multipart) cvtask det response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models/upload (multipart) cvtask det response CVTask": (r) =>
-          r.json().CVTask === "DETECTION",   
-          "POST /models/upload (multipart) cvtask det response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
+          r.status === 200,
+          "POST /models/upload (multipart) task det response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models/upload (multipart) task det response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models/upload (multipart) task det response task": (r) =>
+          r.json().Task === "TASK_DETECTION",
+          "POST /models/upload (multipart) task det response Versions": (r) =>
+          r.json().Versions.length === 1,
       });
 
       let payload = JSON.stringify({
-        "status": 1
+        "status": 2,
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH ${apiHost}/models/${model_name}/versions/1 det response Status`]: (r) =>
-          r.status === 200, 
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 det response Name`]: (r) =>
-          r.json().name !== undefined,      
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 det response FullName`]: (r) =>
-          r.json().full_Name !== undefined,   
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 det response CVTask`]: (r) =>
-          r.json().cv_task === "DETECTION",   
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 det response Versions`]: (r) =>
-          r.json().versions.length === 1,       
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 det response Version 1 Status`]: (r) =>
-          r.json().versions[0].status === "ONLINE",  
-      });  
+        [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response status`]: (r) =>
+          r.status === 200, // TODO: update status to 201
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          r.json().model_version.version !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          r.json().model_version.model_id !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          r.json().model_version.description !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          r.json().model_version.created_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          r.json().model_version.updated_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          r.json().model_version.status === "STATUS_ONLINE",
+      });
 
       // Predict with url
       payload = JSON.stringify({
-        "contents": [{"url": "https://artifacts.instill.tech/dog.jpg"}],
+        "inputs": [{"image_url": "https://artifacts.instill.tech/dog.jpg"}],
       });
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
         [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response Status`]: (r) =>
-          r.status === 200, 
+          r.status === 200,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det contents`]: (r) =>
-          r.json().contents.length === 1,  
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response contents.contents`]: (r) =>
-          r.json().contents[0].contents.length === 1,     
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response contents.contents.category`]: (r) =>
-          r.json().contents[0].contents[0].category === "test",     
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response contents.contents.score`]: (r) =>
-          r.json().contents[0].contents[0].score === 1,  
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response contents.contents.score`]: (r) =>
-          r.json().contents[0].contents[0].box !== undefined,                                          
-      });  
+          r.json().output.detection_output.length === 1,
+          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response category`]: (r) =>
+          r.json().output.detection_output[0].bounding_box_objects[0].category === "test",
+          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response score`]: (r) =>
+          r.json().output.detection_output[0].bounding_box_objects[0].score !== undefined,
+          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response bounding_box`]: (r) =>
+          r.json().output.detection_output[0].bounding_box_objects[0].bounding_box !== undefined,
+      });
 
       // Predict with base64
       payload = JSON.stringify({
-        "contents": [{"base64": base64_image,}]
+        "inputs": [{"image_base64": base64_image,}]
       });
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
         [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response Status`]: (r) =>
-          r.status === 200, 
+          r.status === 200,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det contents`]: (r) =>
-          r.json().contents.length === 1,  
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response contents.contents`]: (r) =>
-          r.json().contents[0].contents.length === 1,     
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response contents.contents.category`]: (r) =>
-          r.json().contents[0].contents[0].category === "test",     
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response contents.contents.score`]: (r) =>
-          r.json().contents[0].contents[0].score === 1,  
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response contents.contents.score`]: (r) =>
-          r.json().contents[0].contents[0].box !== undefined,          
-      });  
+          r.json().output.detection_output.length === 1,
+          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response category`]: (r) =>
+          r.json().output.detection_output[0].bounding_box_objects[0].category === "test",
+          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response score`]: (r) =>
+          r.json().output.detection_output[0].bounding_box_objects[0].score !== undefined,
+          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response bounding_box`]: (r) =>
+          r.json().output.detection_output[0].bounding_box_objects[0].bounding_box !== undefined,
+      });
 
       // Predict with multiple-part
       const fd = new FormData();
-      fd.append("contents", http.file(dog_img));
+      fd.append("inputs", http.file(dog_img));
       check(http.post(`${apiHost}/models/${model_name}/versions/1/upload/outputs`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
         [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response Status`]: (r) =>
-          r.status === 200, 
+          r.status === 200,
           [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det contents`]: (r) =>
-          r.json().contents.length === 1,  
-          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response contents.contents`]: (r) =>
-          r.json().contents[0].contents.length === 1,     
-          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response contents.contents.category`]: (r) =>
-          r.json().contents[0].contents[0].category === "test",     
-          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response contents.contents.score`]: (r) =>
-          r.json().contents[0].contents[0].score === 1,  
-          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response contents.contents.score`]: (r) =>
-          r.json().contents[0].contents[0].box !== undefined,         
-      });      
-      
+          r.json().output.detection_output[0].bounding_box_objects.length === 1,
+          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response category`]: (r) =>
+          r.json().output.detection_output[0].bounding_box_objects[0].category === "test",
+          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response score`]: (r) =>
+          r.json().output.detection_output[0].bounding_box_objects[0].score !== undefined,
+          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response bounding_box`]: (r) =>
+          r.json().output.detection_output[0].bounding_box_objects[0].bounding_box !== undefined,
+      });
+
       // clean up
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      });   
+      });
+
+      // Triton unloading models takes time
+      sleep(4)
     });
-  }   
+  }
 
   // Model Backend API: make inference
   {
-    group("Model Backend API: Predict Model with undefined cvtask model", function () {
+    group("Model Backend API: Predict Model with undefined task model", function () {
       let fd = new FormData();
       let model_name = randomString(10)
       console.log("Create model ", model_name)
@@ -574,102 +583,107 @@ export default function (data) {
       }), {
         "POST /models (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask cls response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().CVTask === "UNDEFINED",   
-          "POST /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
+          "POST /models (multipart) task cls response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task cls response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task cls response task": (r) =>
+          r.json().Task === "TASK_UNSPECIFIED",
+          "POST /models (multipart) task cls response Versions": (r) =>
+          r.json().Versions.length === 1,
       });
 
       let payload = JSON.stringify({
-        "status": 1
+        "status": 2,
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        "PATCH /models/ (multipart) cls response Status": (r) =>
+        [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          "PATCH /models (multipart) cvtask cls response Name": (r) =>
-          r.json().name !== undefined,      
-          "PATCH /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().full_Name !== undefined,   
-          "PATCH /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().cv_task === "UNDEFINED",   
-          "PATCH /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().versions.length === 1,       
-          "PATCH /models (multipart) cvtask cls response Version 1 Status": (r) =>
-          r.json().versions[0].status === "ONLINE",  
-      });  
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          r.json().model_version.version !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          r.json().model_version.model_id !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          r.json().model_version.description !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          r.json().model_version.created_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          r.json().model_version.updated_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          r.json().model_version.status === "STATUS_ONLINE",
+      });
 
       // Predict with url
       payload = JSON.stringify({
-        "contents": [{"url": "https://artifacts.instill.tech/dog.jpg"}]
+        "inputs": [{"image_url": "https://artifacts.instill.tech/dog.jpg"}]
       });
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
         [`POST ${apiHost}/models/${model_name}/versions/1/outputs url undefined response Status`]: (r) =>
-          r.status === 200, 
+          r.status === 200,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs url undefined outputs`]: (r) =>
-          r.json().outputs.length === 1,  
+          r.json().output.outputs.length === 1,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs url undefined parameters`]: (r) =>
-          r.json().parameters !== undefined,            
+          r.json().output.parameters !== undefined,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs url undefined raw_output_contents`]: (r) =>
-          r.json().raw_output_contents.length === 1,   
+          r.json().output.raw_output_contents.length === 1,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs url undefined raw_output_contents content`]: (r) =>
-          r.json().raw_output_contents[0] !== undefined,          
-      });  
+          r.json().output.raw_output_contents[0] !== undefined,
+      });
 
       // Predict with base64
       payload = JSON.stringify({
-        "contents": [{"base64": base64_image,}]
+        "inputs": [{"image_base64": base64_image,}]
       });
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
         [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 undefined response Status`]: (r) =>
-          r.status === 200, 
+          r.status === 200,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 undefined outputs`]: (r) =>
-          r.json().outputs.length === 1,  
+          r.json().output.outputs.length === 1,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 undefined parameters`]: (r) =>
-          r.json().parameters !== undefined,            
+          r.json().output.parameters !== undefined,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 undefined raw_output_contents`]: (r) =>
-          r.json().raw_output_contents.length === 1,   
+          r.json().output.raw_output_contents.length === 1,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 undefined raw_output_contents content`]: (r) =>
-          r.json().raw_output_contents[0] !== undefined,             
-      });  
+          r.json().output.raw_output_contents[0] !== undefined,
+      });
 
       // Predict with multiple-part
       fd = new FormData();
-      fd.append("contents", http.file(dog_img));
+      fd.append("inputs", http.file(dog_img));
       check(http.post(`${apiHost}/models/${model_name}/versions/1/upload/outputs`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
         [`POST ${apiHost}/models/${model_name}/versions/1/outputs multipart undefined response Status`]: (r) =>
-          r.status === 200, 
+          r.status === 200,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs multipart undefined outputs`]: (r) =>
-          r.json().outputs.length === 1,  
+          r.json().output.outputs.length === 1,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs multipart undefined parameters`]: (r) =>
-          r.json().parameters !== undefined,            
+          r.json().output.parameters !== undefined,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs multipart undefined raw_output_contents`]: (r) =>
-          r.json().raw_output_contents.length === 1,   
+          r.json().output.raw_output_contents.length === 1,
           [`POST ${apiHost}/models/${model_name}/versions/1/outputs multipart undefined raw_output_contents content`]: (r) =>
-          r.json().raw_output_contents[0] !== undefined,            
-      });      
-      
+          r.json().output.raw_output_contents[0] !== undefined,
+      });
+
       // clean up
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      });   
+      });
+
+      // Triton unloading models takes time
+      sleep(4)
     });
-  }  
-  
+  }
+
   // Model Backend API: Get model info
   {
     group("Model Backend API: Get model info", function () {
@@ -678,53 +692,55 @@ export default function (data) {
       console.log("Create model ", model_name)
       fd_cls.append("name", model_name);
       fd_cls.append("description", randomString(20));
-      fd_cls.append("cvtask", "DETECTION");
+      fd_cls.append("task", "TASK_DETECTION");
       fd_cls.append("content", http.file(det_model, "dummy-det-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
         "POST /models/upload (multipart) det response Status": (r) =>
-          r.status === 200, 
-          "POST /models/upload (multipart) cvtask det response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models/upload (multipart) cvtask det response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models/upload (multipart) cvtask det response CVTask": (r) =>
-          r.json().CVTask === "DETECTION",   
-          "POST /models/upload (multipart) cvtask det response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
+          r.status === 200,
+          "POST /models/upload (multipart) task det response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models/upload (multipart) task det response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models/upload (multipart) task det response task": (r) =>
+          r.json().Task === "TASK_DETECTION",
+          "POST /models/upload (multipart) task det response Versions": (r) =>
+          r.json().Versions.length === 1,
       });
-
       check(http.get(`${apiHost}/models/${model_name}`, {
         headers: genHeader(`application/json`),
       }), {
         [`GET ${apiHost}/models/${model_name} response Status`]: (r) =>
-          r.status === 200, 
+          r.status === 200,
           [`GET ${apiHost}/models/${model_name} cv_task`]: (r) =>
-          r.json().cv_task === "DETECTION",  
+          r.json().model.task === "TASK_DETECTION",
           [`GET ${apiHost}/models/${model_name} versions`]: (r) =>
-          r.json().versions.length === 1,  
+          r.json().model.model_versions.length === 1,
           [`GET ${apiHost}/models/${model_name} version created_at`]: (r) =>
-          r.json().versions[0].created_at !== undefined,                      
+          r.json().model.model_versions[0].created_at !== undefined,
           [`GET ${apiHost}/models/${model_name} version updated_at`]: (r) =>
-          r.json().versions[0].updated_at !== undefined,   
+          r.json().model.model_versions[0].updated_at !== undefined,
           [`GET ${apiHost}/models/${model_name} version status`]: (r) =>
-          r.json().versions[0].status === "OFFLINE",            
+          r.json().model.model_versions[0].status === "STATUS_OFFLINE",
           [`GET ${apiHost}/models/${model_name} id`]: (r) =>
-          r.json().id !== undefined,   
+          r.json().model.id !== undefined,
           [`GET ${apiHost}/models/${model_name} full_Name`]: (r) =>
-          r.json().full_Name === `local-user/${model_name}`,                                
-      });      
-      
+          r.json().model.full_name === `local-user/${model_name}`,
+      });
+
       // clean up
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      });   
+      });
+
+      // Triton unloading models takes time
+      sleep(4)
     });
-  }   
+  }
 
  // Model Backend API: Get model list
   {
@@ -734,54 +750,56 @@ export default function (data) {
       console.log("Create model ", model_name)
       fd_cls.append("name", model_name);
       fd_cls.append("description", randomString(20));
-      fd_cls.append("cvtask", "DETECTION");
+      fd_cls.append("task", "TASK_DETECTION");
       fd_cls.append("content", http.file(det_model, "dummy-det-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
         "POST /models/upload (multipart) det response Status": (r) =>
-          r.status === 200, 
-          "POST /models/upload (multipart) cvtask det response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models/upload (multipart) cvtask det response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models/upload (multipart) cvtask det response CVTask": (r) =>
-          r.json().CVTask === "DETECTION",   
-          "POST /models/upload (multipart) cvtask det response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
+          r.status === 200,
+          "POST /models/upload (multipart) task det response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models/upload (multipart) task det response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models/upload (multipart) task det response task": (r) =>
+          r.json().Task === "TASK_DETECTION",
+          "POST /models/upload (multipart) task det response Versions": (r) =>
+          r.json().Versions.length === 1,
       });
 
-      let res = http.get(`${apiHost}/models`, {
+      check(http.get(`${apiHost}/models`, {
         headers: genHeader(`application/json`),
-      })
-      check(res, {
+      }), {
         [`GET ${apiHost}/models response Status`]: (r) =>
-          r.status === 200, 
+          r.status === 200,
           [`GET ${apiHost}/models cv_task`]: (r) =>
-          r.json().models[0].cv_task !== undefined,  
+          r.json().models[0].task !== undefined,
           [`GET ${apiHost}/models versions`]: (r) =>
-          r.json().models[0].versions.length > 0,  
+          r.json().models[0].model_versions.length > 0,
           [`GET ${apiHost}/models version created_at`]: (r) =>
-          r.json().models[0].versions[0].created_at !== undefined,                      
+          r.json().models[0].model_versions[0].created_at !== undefined,
           [`GET ${apiHost}/models version updated_at`]: (r) =>
-          r.json().models[0].versions[0].updated_at !== undefined,   
+          r.json().models[0].model_versions[0].updated_at !== undefined,
           [`GET ${apiHost}/models version status`]: (r) =>
-          r.json().models[0].versions[0].status !== undefined,            
+          r.json().models[0].model_versions[0].status !== undefined,
           [`GET ${apiHost}/models id`]: (r) =>
-          r.json().models[0].id !== undefined,   
+          r.json().models[0].id !== undefined,
           [`GET ${apiHost}/models full_Name`]: (r) =>
-          r.json().models[0].full_Name !== undefined,                                
-      });      
-      
+          r.json().models[0].full_name !== undefined,
+      });
+
       // clean up
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      });   
+      });
+
+      // Triton unloading models takes time
+      sleep(4)
     });
-  }   
+  }
 
   // Model Backend API: update model version description
   {
@@ -791,21 +809,21 @@ export default function (data) {
       console.log("Create model ", model_name)
       fd_cls.append("name", model_name);
       fd_cls.append("description", randomString(20));
-      fd_cls.append("cvtask", "CLASSIFICATION");
+      fd_cls.append("task", "TASK_CLASSIFICATION");
       fd_cls.append("content", http.file(cls_model, "dummy-cls-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
         "POST /models (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask cls response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().CVTask === "CLASSIFICATION",   
-          "POST /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().Versions.length === 1,                                        
+          "POST /models (multipart) task cls response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task cls response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task cls response task": (r) =>
+          r.json().Task === "TASK_CLASSIFICATION",
+          "POST /models (multipart) task cls response Versions": (r) =>
+          r.json().Versions.length === 1,
       });
 
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
@@ -813,83 +831,105 @@ export default function (data) {
       }), {
         "POST /models (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) cvtask cls response Name": (r) =>
-          r.json().Name !== undefined,      
-          "POST /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().FullName !== undefined,   
-          "POST /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().CVTask === "CLASSIFICATION",   
-          "POST /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().Versions.length === 2,                                        
-      });      
+          "POST /models (multipart) task cls response Name": (r) =>
+          r.json().Name !== undefined,
+          "POST /models (multipart) task cls response FullName": (r) =>
+          r.json().FullName !== undefined,
+          "POST /models (multipart) task cls response task": (r) =>
+          r.json().Task === "TASK_CLASSIFICATION",
+          "POST /models (multipart) task cls response Versions": (r) =>
+          r.json().Versions.length === 2,
+      });
 
       let new_description = randomString(20)
       let payload = JSON.stringify({
-        "status": 1,
-        "description": new_description
+        "description": new_description,
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        "PATCH /models (multipart) cls response Status": (r) =>
+        [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          "PATCH /models (multipart) cvtask cls response Name": (r) =>
-          r.json().name !== undefined,      
-          "PATCH /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().full_Name !== undefined,   
-          "PATCH /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().cv_task === "CLASSIFICATION",   
-          "PATCH /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().versions.length === 2,       
-          "PATCH /models (multipart) cvtask cls response Version 1 Status": (r) =>
-          r.json().versions[0].status === "ONLINE",  
-          "PATCH /models (multipart) cvtask cls response Version 2 Status": (r) =>
-          r.json().versions[1].status === "OFFLINE",  
-          "PATCH /models (multipart) cvtask cls response Version 1 Description": (r) =>
-          r.json().versions[0].description === new_description,                                                                      
-      });  
-      
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          r.json().model_version.version !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          r.json().model_version.model_id !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          r.json().model_version.description === new_description,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          r.json().model_version.created_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          r.json().model_version.updated_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          r.json().model_version.status !== undefined,
+      });
+
       let new_description2 = randomString(20)
       payload = JSON.stringify({
-        "status": 1,
-        "description": new_description2
+        "description": new_description2,
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/2`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        "PATCH /models (multipart) cls response Status": (r) =>
+        [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          "PATCH /models (multipart) cvtask cls response Name": (r) =>
-          r.json().name !== undefined,      
-          "PATCH /models (multipart) cvtask cls response FullName": (r) =>
-          r.json().full_Name !== undefined,   
-          "PATCH /models (multipart) cvtask cls response CVTask": (r) =>
-          r.json().cv_task === "CLASSIFICATION",   
-          "PATCH /models (multipart) cvtask cls response Versions": (r) =>
-          r.json().versions.length === 2,       
-          "PATCH /models (multipart) cvtask cls response Version 1 Status": (r) =>
-          r.json().versions[0].status === "ONLINE",  
-          "PATCH /models (multipart) cvtask cls response Version 2 Status": (r) =>
-          r.json().versions[1].status === "ONLINE",  
-          "PATCH /models (multipart) cvtask cls response Version 1 Description": (r) =>
-          r.json().versions[0].description === new_description,              
-          "PATCH /models (multipart) cvtask cls response Version 2 Description": (r) =>
-          r.json().versions[1].description === new_description2,                                                                      
-      });         
-      
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response version`]: (r) =>
+          r.json().model_version.version !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response model_id`]: (r) =>
+          r.json().model_version.model_id !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response description`]: (r) =>
+          r.json().model_version.description === new_description2,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response created_at`]: (r) =>
+          r.json().model_version.created_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response updated_at`]: (r) =>
+          r.json().model_version.updated_at !== undefined,
+          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response model version status`]: (r) =>
+          r.json().model_version.status !== undefined,
+      });
+
       // clean up
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
-      });   
+      });
+
+      // Triton unloading models takes time
+      sleep(4)
     });
-  }  
+  }
 
   sleep(1);
 }
 
 export function teardown(data) {
-
+  group("Model API: Delete all models created by this test", () => {
+    let res = http
+    .request("GET", `${apiHost}/models`, null, {
+      headers: genHeader(
+        "application/json"
+      ),
+    })
+    for (const model of http
+      .request("GET", `${apiHost}/models`, null, {
+        headers: genHeader(
+          "application/json"
+        ),
+      })
+      .json("models")) {
+      check(model, {
+        "GET /clients response contents[*] id": (c) => c.id !== undefined,
+      });
+      check(
+        http.request("DELETE", `${apiHost}/models/${model.name}`, null, {
+          headers: genHeader("application/json"),
+        }),
+        {
+          [`DELETE /models/${model.name} response status is 204`]: (r) =>
+            r.status === 200, //TODO: update to 204
+        }
+      );
+    }
+  });
 }

--- a/tests/integration-tests/model-backend-rest.js
+++ b/tests/integration-tests/model-backend-rest.js
@@ -46,80 +46,81 @@ export default function (data) {
   {
     group("Model Backend API: Upload a model", function () {
       let fd_cls = new FormData();
-      let model_name1 = randomString(10)
-      fd_cls.append("name", model_name1);
+      let model_name_cls = randomString(10)
+      fd_cls.append("name", model_name_cls);
       fd_cls.append("description", randomString(20));
       fd_cls.append("task", "TASK_CLASSIFICATION");
       fd_cls.append("content", http.file(cls_model, "dummy-cls-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models (multipart) task cls response Status": (r) =>
+        "POST /models/upload (multipart) task cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task cls response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task cls response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task cls response task": (r) =>
-          r.json().Task === "TASK_CLASSIFICATION",
-          "POST /models (multipart) task cls response Versions": (r) =>
-          r.json().Versions.length === 1,
+          "POST /models/upload (multipart) task cls response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task cls response task": (r) =>
+          r.json().model.task === "TASK_CLASSIFICATION",
+          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          r.json().model.modelVersions.length === 1,
       });
 
       let fd_det = new FormData();
-      let model_name2 = randomString(10)
-      fd_det.append("name", model_name2);
+      let model_name_det = randomString(10)
+      fd_det.append("name", model_name_det);
       fd_det.append("description", randomString(20));
       fd_det.append("task", "TASK_DETECTION");
-      fd_det.append("content", http.file(cls_model, "dummy-det-model.zip"));
+      fd_det.append("content", http.file(det_model, "dummy-det-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_det.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_det.boundary}`),
       }), {
-        "POST /models (multipart) task det response Status": (r) =>
+        "POST /models/upload (multipart) task det response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task det response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task det response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task det response task": (r) =>
-          r.json().Task === "TASK_DETECTION",
-          "POST /models (multipart) task det response Versions": (r) =>
-          r.json().Versions.length === 1,
+          "POST /models/upload (multipart) task det response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task det response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task det response task": (r) =>
+          r.json().model.task === "TASK_DETECTION",
+          "POST /models/upload (multipart) task det response Versions": (r) =>
+          r.json().model.modelVersions.length === 1,
       });
 
       let fd_undefined = new FormData();
-      let model_name3 = randomString(10)
-      fd_undefined.append("name", model_name3);
+      let model_name_unspecified = randomString(10)
+      fd_undefined.append("name", model_name_unspecified);
       fd_undefined.append("description", randomString(20));
-      fd_undefined.append("content", http.file(cls_model, "dummy-det-model.zip"));
+      fd_undefined.append("content", http.file(det_model, "dummy-det-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_undefined.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_undefined.boundary}`),
       }), {
-        "POST /models (multipart) task undefined response Status": (r) =>
+        "POST /models/upload (multipart) task undefined response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task undefined response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task undefined response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task undefined response task": (r) =>
-          r.json().Task === "TASK_UNSPECIFIED",
-          "POST /models (multipart) task undefined response Versions": (r) =>
-          r.json().Versions.length === 1,
+          "POST /models/upload (multipart) task undefined response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task undefined response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task undefined response task": (r) =>
+          r.json().model.task === undefined, //default value of TASK_UNSPECIFIED task is 0 which not in response
+          "POST /models/upload (multipart) task undefined response Versions": (r) =>
+          r.json().model.modelVersions.length === 1,
       });
+
       // clean up
-      check(http.request("DELETE", `${apiHost}/models/${model_name1}`, null, {
+      check(http.request("DELETE", `${apiHost}/models/${model_name_cls}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
-      check(http.request("DELETE", `${apiHost}/models/${model_name2}`, null, {
+      check(http.request("DELETE", `${apiHost}/models/${model_name_det}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
           r.status === 200 // TODO: update status to 204
       });
-      check(http.request("DELETE", `${apiHost}/models/${model_name3}`, null, {
+      check(http.request("DELETE", `${apiHost}/models/${model_name_unspecified}`, null, {
         headers: genHeader(`application/json`),
       }), {
         "DELETE clean up response Status": (r) =>
@@ -140,56 +141,57 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task cls response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task cls response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task cls response task": (r) =>
-          r.json().Task === "TASK_CLASSIFICATION",
-          "POST /models (multipart) task cls response Versions": (r) =>
-          r.json().Versions.length === 1,
+          "POST /models/upload (multipart) task cls response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task cls response task": (r) =>
+          r.json().model.task === "TASK_CLASSIFICATION",
+          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          r.json().model.modelVersions.length === 1,
       });
 
       let fd_det = new FormData();
       fd_det.append("name", model_name);
       fd_det.append("description", randomString(20));
       fd_det.append("task", "TASK_DETECTION");
-      fd_det.append("content", http.file(cls_model, "dummy-det-model.zip"));
+      fd_det.append("content", http.file(det_model, "dummy-det-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_det.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_det.boundary}`),
       }), {
-        "POST /models (multipart) det response Status": (r) =>
+        "POST /models/upload (multipart) det response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task det response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task det response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task det response task": (r) =>
-          r.json().Task === "TASK_CLASSIFICATION",
-          "POST /models (multipart) task det response Versions": (r) =>
-          r.json().Versions.length === 2,
+          "POST /models/upload (multipart) task det response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task det response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task det response task": (r) =>
+          r.json().model.task === "TASK_CLASSIFICATION",
+          "POST /models/upload (multipart) task det response Versions": (r) =>
+          r.json().model.modelVersions.length === 2,
       });
 
       let fd_undefined = new FormData();
       fd_undefined.append("name", model_name);
       fd_undefined.append("description", randomString(20));
-      fd_undefined.append("content", http.file(cls_model, "dummy-det-model.zip"));
+      fd_undefined.append("content", http.file(det_model, "dummy-det-model.zip"));
       check(http.request("POST", `${apiHost}/models/upload`, fd_undefined.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_undefined.boundary}`),
       }), {
-        "POST /models (multipart) undefined response Status": (r) =>
+        "POST /models/upload (multipart) undefined response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task undefined response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task undefined response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task undefined response task": (r) =>
-          r.json().Task === "TASK_CLASSIFICATION",
-          "POST /models (multipart) task undefined response Versions": (r) =>
-          r.json().Versions.length === 3,
+          "POST /models/upload (multipart) task undefined response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task undefined response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task undefined response task": (r) =>
+          r.json().model.task === "TASK_CLASSIFICATION",
+          "POST /models/upload (multipart) task undefined response Versions": (r) =>
+          r.json().model.modelVersions.length === 3,
       });
+
       // clean up
       check(http.request("DELETE", `${apiHost}/models/${model_name}`, null, {
         headers: genHeader(`application/json`),
@@ -213,121 +215,121 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task cls response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task cls response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task cls response task": (r) =>
-          r.json().Task === "TASK_CLASSIFICATION",
-          "POST /models (multipart) task cls response Versions": (r) =>
-          r.json().Versions.length === 1,
+          "POST /models/upload (multipart) task cls response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task cls response task": (r) =>
+          r.json().model.task === "TASK_CLASSIFICATION",
+          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          r.json().model.modelVersions.length === 1,
       });
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task cls response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task cls response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task cls response task": (r) =>
-          r.json().Task === "TASK_CLASSIFICATION",
-          "POST /models (multipart) task cls response Versions": (r) =>
-          r.json().Versions.length === 2,
+          "POST /models/upload (multipart) task cls response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task cls response task": (r) =>
+          r.json().model.task === "TASK_CLASSIFICATION",
+          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          r.json().model.modelVersions.length === 2,
       });
 
       let payload = JSON.stringify({
-        "status": 2,
+        "status": "STATUS_ONLINE",
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response Status`]: (r) =>
+        [`PATCH /models/${model_name}/versions/1 online task cls response Status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response version`]: (r) =>
-          r.json().model_version.version !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
-          r.json().model_version.model_id !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response description`]: (r) =>
-          r.json().model_version.description !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
-          r.json().model_version.created_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
-          r.json().model_version.updated_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
-          r.json().model_version.status === "STATUS_ONLINE",
+          [`PATCH /models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          r.json().modelVersion.version !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          r.json().modelVersion.modelId !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          r.json().modelVersion.description !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          r.json().modelVersion.createdAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          r.json().modelVersion.updatedAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          r.json().modelVersion.status === "STATUS_ONLINE",
       });
 
       payload = JSON.stringify({
-        "status": 2,
+        "status": "STATUS_ONLINE",
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/2`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response status`]: (r) =>
+        [`PATCH /models/${model_name}/versions/2 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response version`]: (r) =>
-          r.json().model_version.version !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response model_id`]: (r) =>
-          r.json().model_version.model_id !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response description`]: (r) =>
-          r.json().model_version.description !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response created_at`]: (r) =>
-          r.json().model_version.created_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response updated_at`]: (r) =>
-          r.json().model_version.updated_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response model version status`]: (r) =>
-          r.json().model_version.status === "STATUS_ONLINE",
+          [`PATCH /models/${model_name}/versions/2 online task cls response version`]: (r) =>
+          r.json().modelVersion.version !== undefined,
+          [`PATCH /models/${model_name}/versions/2 online task cls response model_id`]: (r) =>
+          r.json().modelVersion.modelId !== undefined,
+          [`PATCH /models/${model_name}/versions/2 online task cls response description`]: (r) =>
+          r.json().modelVersion.description !== undefined,
+          [`PATCH /models/${model_name}/versions/2 online task cls response created_at`]: (r) =>
+          r.json().modelVersion.createdAt !== undefined,
+          [`PATCH /models/${model_name}/versions/2 online task cls response updated_at`]: (r) =>
+          r.json().modelVersion.updatedAt !== undefined,
+          [`PATCH /models/${model_name}/versions/2 online task cls response model version status`]: (r) =>
+          r.json().modelVersion.status === "STATUS_ONLINE",
       });
 
       payload = JSON.stringify({
-        "status": 1,
+        "status": "STATUS_OFFLINE",
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response status`]: (r) =>
+        [`PATCH /models/${model_name}/versions/1 offline task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response Version`]: (r) =>
-          r.json().model_version.version !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response model_id`]: (r) =>
-          r.json().model_version.model_id !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response description`]: (r) =>
-          r.json().model_version.description !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response created_at`]: (r) =>
-          r.json().model_version.created_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response updated_at`]: (r) =>
-          r.json().model_version.updated_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 offline task cls response model version status`]: (r) =>
-          r.json().model_version.status === "STATUS_OFFLINE",
+          [`PATCH /models/${model_name}/versions/1 offline task cls response Version`]: (r) =>
+          r.json().modelVersion.version !== undefined,
+          [`PATCH /models/${model_name}/versions/1 offline task cls response model_id`]: (r) =>
+          r.json().modelVersion.modelId !== undefined,
+          [`PATCH /models/${model_name}/versions/1 offline task cls response description`]: (r) =>
+          r.json().modelVersion.description !== undefined,
+          [`PATCH /models/${model_name}/versions/1 offline task cls response created_at`]: (r) =>
+          r.json().modelVersion.createdAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 offline task cls response updated_at`]: (r) =>
+          r.json().modelVersion.updatedAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 offline task cls response model version status`]: (r) =>
+          r.json().modelVersion.status === "STATUS_OFFLINE",
       });
 
       // Triton unloading models takes time
       sleep(4)
 
       payload = JSON.stringify({
-        "status": 1,
+        "status": "STATUS_OFFLINE",
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/2`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response status`]: (r) =>
+        [`PATCH /models/${model_name}/versions/2 offline task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response Version`]: (r) =>
-          r.json().model_version.version !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response model_id`]: (r) =>
-          r.json().model_version.model_id !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response description`]: (r) =>
-          r.json().model_version.description !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response created_at`]: (r) =>
-          r.json().model_version.created_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response updated_at`]: (r) =>
-          r.json().model_version.updated_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 offline task cls response model version status`]: (r) =>
-          r.json().model_version.status === "STATUS_OFFLINE",
+          [`PATCH /models/${model_name}/versions/2 offline task cls response Version`]: (r) =>
+          r.json().modelVersion.version !== undefined,
+          [`PATCH /models/${model_name}/versions/2 offline task cls response model_id`]: (r) =>
+          r.json().modelVersion.modelId !== undefined,
+          [`PATCH /models/${model_name}/versions/2 offline task cls response description`]: (r) =>
+          r.json().modelVersion.description !== undefined,
+          [`PATCH /models/${model_name}/versions/2 offline task cls response created_at`]: (r) =>
+          r.json().modelVersion.createdAt !== undefined,
+          [`PATCH /models/${model_name}/versions/2 offline task cls response updated_at`]: (r) =>
+          r.json().modelVersion.updatedAt !== undefined,
+          [`PATCH /models/${model_name}/versions/2 offline task cls response model version status`]: (r) =>
+          r.json().modelVersion.status === "STATUS_OFFLINE",
       });
 
       // clean up
@@ -356,38 +358,38 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task cls response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task cls response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task cls response task": (r) =>
-          r.json().Task === "TASK_CLASSIFICATION",
-          "POST /models (multipart) task cls response Versions": (r) =>
-          r.json().Versions.length === 1,
+          "POST /models/upload (multipart) task cls response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task cls response task": (r) =>
+          r.json().model.task === "TASK_CLASSIFICATION",
+          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          r.json().model.modelVersions.length === 1,
       });
 
       let payload = JSON.stringify({
-        "status": 2
+        "status": "STATUS_ONLINE"
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response status`]: (r) =>
+        [`PATCH /models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response version`]: (r) =>
-          r.json().model_version.version !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
-          r.json().model_version.model_id !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response description`]: (r) =>
-          r.json().model_version.description !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
-          r.json().model_version.created_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
-          r.json().model_version.updated_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
-          r.json().model_version.status === "STATUS_ONLINE",
+          [`PATCH /models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          r.json().modelVersion.version !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          r.json().modelVersion.modelId !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          r.json().modelVersion.description !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          r.json().modelVersion.createdAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          r.json().modelVersion.updatedAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          r.json().modelVersion.status === "STATUS_ONLINE",
       });
 
       // Predict with url
@@ -397,14 +399,14 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST ${apiHost}/models/${model_name}/versions/1/outputs url cls response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs url cls response Status`]: (r) =>
           r.status === 200,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url cls contents`]: (r) =>
-          r.json().output.classification_outputs.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url cls contents.category`]: (r) =>
-          r.json().output.classification_outputs[0].category === "match",
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url cls response contents.score`]: (r) =>
-          r.json().output.classification_outputs[0].score === 1,
+          [`POST /models/${model_name}/versions/1/outputs url cls contents`]: (r) =>
+          r.json().output.classificationOutputs.length === 1,
+          [`POST /models/${model_name}/versions/1/outputs url cls contents.category`]: (r) =>
+          r.json().output.classificationOutputs[0].category === "match",
+          [`POST /models/${model_name}/versions/1/outputs url cls response contents.score`]: (r) =>
+          r.json().output.classificationOutputs[0].score === 1,
       });
 
       // Predict with base64
@@ -414,14 +416,14 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs base64 cls response Status`]: (r) =>
           r.status === 200,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls contents`]: (r) =>
-          r.json().output.classification_outputs.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls contents.category`]: (r) =>
-          r.json().output.classification_outputs[0].category === "match",
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 cls response contents.score`]: (r) =>
-          r.json().output.classification_outputs[0].score === 1,
+          [`POST /models/${model_name}/versions/1/outputs base64 cls contents`]: (r) =>
+          r.json().output.classificationOutputs.length === 1,
+          [`POST /models/${model_name}/versions/1/outputs base64 cls contents.category`]: (r) =>
+          r.json().output.classificationOutputs[0].category === "match",
+          [`POST /models/${model_name}/versions/1/outputs base64 cls response contents.score`]: (r) =>
+          r.json().output.classificationOutputs[0].score === 1,
       });
 
       // Predict with multiple-part
@@ -430,14 +432,14 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/upload/outputs`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
-        [`POST ${apiHost}/models/${model_name}/versions/1/outputs form-data cls response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/upload/outputs form-data cls response Status`]: (r) =>
           r.status === 200,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs form-data cls contents`]: (r) =>
-          r.json().output.classification_outputs.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs form-data cls contents.category`]: (r) =>
-          r.json().output.classification_outputs[0].category === "match",
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs form-data cls response contents.score`]: (r) =>
-          r.json().output.classification_outputs[0].score === 1,
+          [`POST /models/${model_name}/versions/1/upload/outputs form-data cls contents`]: (r) =>
+          r.json().output.classificationOutputs.length === 1,
+          [`POST /models/${model_name}/versions/1/upload/outputs form-data cls contents.category`]: (r) =>
+          r.json().output.classificationOutputs[0].category === "match",
+          [`POST /models/${model_name}/versions/1/upload/outputs form-data cls response contents.score`]: (r) =>
+          r.json().output.classificationOutputs[0].score === 1,
       });
 
       // clean up
@@ -469,35 +471,35 @@ export default function (data) {
         "POST /models/upload (multipart) det response Status": (r) =>
           r.status === 200,
           "POST /models/upload (multipart) task det response Name": (r) =>
-          r.json().Name !== undefined,
+          r.json().model.name !== undefined,
           "POST /models/upload (multipart) task det response FullName": (r) =>
-          r.json().FullName !== undefined,
+          r.json().model.fullName !== undefined,
           "POST /models/upload (multipart) task det response task": (r) =>
-          r.json().Task === "TASK_DETECTION",
+          r.json().model.task === "TASK_DETECTION",
           "POST /models/upload (multipart) task det response Versions": (r) =>
-          r.json().Versions.length === 1,
+          r.json().model.modelVersions.length === 1,
       });
 
       let payload = JSON.stringify({
-        "status": 2,
+        "status": "STATUS_ONLINE",
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response status`]: (r) =>
+        [`PATCH /models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response version`]: (r) =>
-          r.json().model_version.version !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
-          r.json().model_version.model_id !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response description`]: (r) =>
-          r.json().model_version.description !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
-          r.json().model_version.created_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
-          r.json().model_version.updated_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
-          r.json().model_version.status === "STATUS_ONLINE",
+          [`PATCH /models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          r.json().modelVersion.version !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          r.json().modelVersion.modelId !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          r.json().modelVersion.description !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          r.json().modelVersion.createdAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          r.json().modelVersion.updatedAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          r.json().modelVersion.status === "STATUS_ONLINE",
       });
 
       // Predict with url
@@ -507,16 +509,16 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs url det response Status`]: (r) =>
           r.status === 200,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det contents`]: (r) =>
-          r.json().output.detection_output.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response category`]: (r) =>
-          r.json().output.detection_output[0].bounding_box_objects[0].category === "test",
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response score`]: (r) =>
-          r.json().output.detection_output[0].bounding_box_objects[0].score !== undefined,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url det response bounding_box`]: (r) =>
-          r.json().output.detection_output[0].bounding_box_objects[0].bounding_box !== undefined,
+          [`POST /models/${model_name}/versions/1/outputs url det contents`]: (r) =>
+          r.json().output.detectionOutput.length === 1,
+          [`POST /models/${model_name}/versions/1/outputs url det response category`]: (r) =>
+          r.json().output.detectionOutput[0].boundingBoxObjects[0].category === "test",
+          [`POST /models/${model_name}/versions/1/outputs url det response score`]: (r) =>
+          r.json().output.detectionOutput[0].boundingBoxObjects[0].score !== undefined,
+          [`POST /models/${model_name}/versions/1/outputs url det response bounding_box`]: (r) =>
+          r.json().output.detectionOutput[0].boundingBoxObjects[0].boundingBox !== undefined,
       });
 
       // Predict with base64
@@ -526,16 +528,16 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs base64 det response Status`]: (r) =>
           r.status === 200,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det contents`]: (r) =>
-          r.json().output.detection_output.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response category`]: (r) =>
-          r.json().output.detection_output[0].bounding_box_objects[0].category === "test",
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response score`]: (r) =>
-          r.json().output.detection_output[0].bounding_box_objects[0].score !== undefined,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 det response bounding_box`]: (r) =>
-          r.json().output.detection_output[0].bounding_box_objects[0].bounding_box !== undefined,
+          [`POST /models/${model_name}/versions/1/outputs base64 det contents`]: (r) =>
+          r.json().output.detectionOutput.length === 1,
+          [`POST /models/${model_name}/versions/1/outputs base64 det response category`]: (r) =>
+          r.json().output.detectionOutput[0].boundingBoxObjects[0].category === "test",
+          [`POST /models/${model_name}/versions/1/outputs base64 det response score`]: (r) =>
+          r.json().output.detectionOutput[0].boundingBoxObjects[0].score !== undefined,
+          [`POST /models/${model_name}/versions/1/outputs base64 det response bounding_box`]: (r) =>
+          r.json().output.detectionOutput[0].boundingBoxObjects[0].boundingBox !== undefined,
       });
 
       // Predict with multiple-part
@@ -544,16 +546,16 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/upload/outputs`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
-        [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response Status`]: (r) =>
           r.status === 200,
-          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det contents`]: (r) =>
-          r.json().output.detection_output[0].bounding_box_objects.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response category`]: (r) =>
-          r.json().output.detection_output[0].bounding_box_objects[0].category === "test",
-          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response score`]: (r) =>
-          r.json().output.detection_output[0].bounding_box_objects[0].score !== undefined,
-          [`POST ${apiHost}/models/${model_name}/versions/1/upload/outputs multiple-part det response bounding_box`]: (r) =>
-          r.json().output.detection_output[0].bounding_box_objects[0].bounding_box !== undefined,
+          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det contents`]: (r) =>
+          r.json().output.detectionOutput[0].boundingBoxObjects.length === 1,
+          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response category`]: (r) =>
+          r.json().output.detectionOutput[0].boundingBoxObjects[0].category === "test",
+          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response score`]: (r) =>
+          r.json().output.detectionOutput[0].boundingBoxObjects[0].score !== undefined,
+          [`POST /models/${model_name}/versions/1/upload/outputs multiple-part det response bounding_box`]: (r) =>
+          r.json().output.detectionOutput[0].boundingBoxObjects[0].boundingBox !== undefined,
       });
 
       // clean up
@@ -581,38 +583,38 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
-        "POST /models (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task cls response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task cls response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task cls response task": (r) =>
-          r.json().Task === "TASK_UNSPECIFIED",
-          "POST /models (multipart) task cls response Versions": (r) =>
-          r.json().Versions.length === 1,
+          "POST /models/upload (multipart) task cls response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task cls response task": (r) =>
+          r.json().model.task === undefined,
+          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          r.json().model.modelVersions.length === 1,
       });
 
       let payload = JSON.stringify({
-        "status": 2,
+        "status": "STATUS_ONLINE",
       });
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response status`]: (r) =>
+        [`PATCH /models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response version`]: (r) =>
-          r.json().model_version.version !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
-          r.json().model_version.model_id !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response description`]: (r) =>
-          r.json().model_version.description !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
-          r.json().model_version.created_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
-          r.json().model_version.updated_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
-          r.json().model_version.status === "STATUS_ONLINE",
+          [`PATCH /models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          r.json().modelVersion.version !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          r.json().modelVersion.modelId !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          r.json().modelVersion.description !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          r.json().modelVersion.createdAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          r.json().modelVersion.updatedAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          r.json().modelVersion.status === "STATUS_ONLINE",
       });
 
       // Predict with url
@@ -622,16 +624,16 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST ${apiHost}/models/${model_name}/versions/1/outputs url undefined response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs url undefined response Status`]: (r) =>
           r.status === 200,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url undefined outputs`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs url undefined outputs`]: (r) =>
           r.json().output.outputs.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url undefined parameters`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs url undefined parameters`]: (r) =>
           r.json().output.parameters !== undefined,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url undefined raw_output_contents`]: (r) =>
-          r.json().output.raw_output_contents.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs url undefined raw_output_contents content`]: (r) =>
-          r.json().output.raw_output_contents[0] !== undefined,
+          [`POST /models/${model_name}/versions/1/outputs url undefined raw_output_contents`]: (r) =>
+          r.json().output.rawOutputContents.length === 1,
+          [`POST /models/${model_name}/versions/1/outputs url undefined raw_output_contents content`]: (r) =>
+          r.json().output.rawOutputContents[0] !== undefined,
       });
 
       // Predict with base64
@@ -641,16 +643,16 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/outputs`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 undefined response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs base64 undefined response Status`]: (r) =>
           r.status === 200,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 undefined outputs`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs base64 undefined outputs`]: (r) =>
           r.json().output.outputs.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 undefined parameters`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs base64 undefined parameters`]: (r) =>
           r.json().output.parameters !== undefined,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 undefined raw_output_contents`]: (r) =>
-          r.json().output.raw_output_contents.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs base64 undefined raw_output_contents content`]: (r) =>
-          r.json().output.raw_output_contents[0] !== undefined,
+          [`POST /models/${model_name}/versions/1/outputs base64 undefined raw_output_contents`]: (r) =>
+          r.json().output.rawOutputContents.length === 1,
+          [`POST /models/${model_name}/versions/1/outputs base64 undefined raw_output_contents content`]: (r) =>
+          r.json().output.rawOutputContents[0] !== undefined,
       });
 
       // Predict with multiple-part
@@ -659,16 +661,16 @@ export default function (data) {
       check(http.post(`${apiHost}/models/${model_name}/versions/1/upload/outputs`, fd.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd.boundary}`),
       }), {
-        [`POST ${apiHost}/models/${model_name}/versions/1/outputs multipart undefined response Status`]: (r) =>
+        [`POST /models/${model_name}/versions/1/outputs multipart undefined response Status`]: (r) =>
           r.status === 200,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs multipart undefined outputs`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs multipart undefined outputs`]: (r) =>
           r.json().output.outputs.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs multipart undefined parameters`]: (r) =>
+          [`POST /models/${model_name}/versions/1/outputs multipart undefined parameters`]: (r) =>
           r.json().output.parameters !== undefined,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs multipart undefined raw_output_contents`]: (r) =>
-          r.json().output.raw_output_contents.length === 1,
-          [`POST ${apiHost}/models/${model_name}/versions/1/outputs multipart undefined raw_output_contents content`]: (r) =>
-          r.json().output.raw_output_contents[0] !== undefined,
+          [`POST /models/${model_name}/versions/1/outputs multipart undefined raw_output_contents`]: (r) =>
+          r.json().output.rawOutputContents.length === 1,
+          [`POST /models/${model_name}/versions/1/outputs multipart undefined raw_output_contents content`]: (r) =>
+          r.json().output.rawOutputContents[0] !== undefined,
       });
 
       // clean up
@@ -700,33 +702,33 @@ export default function (data) {
         "POST /models/upload (multipart) det response Status": (r) =>
           r.status === 200,
           "POST /models/upload (multipart) task det response Name": (r) =>
-          r.json().Name !== undefined,
+          r.json().model.name !== undefined,
           "POST /models/upload (multipart) task det response FullName": (r) =>
-          r.json().FullName !== undefined,
+          r.json().model.fullName !== undefined,
           "POST /models/upload (multipart) task det response task": (r) =>
-          r.json().Task === "TASK_DETECTION",
+          r.json().model.task === "TASK_DETECTION",
           "POST /models/upload (multipart) task det response Versions": (r) =>
-          r.json().Versions.length === 1,
+          r.json().model.modelVersions.length === 1,
       });
       check(http.get(`${apiHost}/models/${model_name}`, {
         headers: genHeader(`application/json`),
       }), {
-        [`GET ${apiHost}/models/${model_name} response Status`]: (r) =>
+        [`GET /models/${model_name} response Status`]: (r) =>
           r.status === 200,
-          [`GET ${apiHost}/models/${model_name} cv_task`]: (r) =>
+          [`GET /models/${model_name} task`]: (r) =>
           r.json().model.task === "TASK_DETECTION",
-          [`GET ${apiHost}/models/${model_name} versions`]: (r) =>
-          r.json().model.model_versions.length === 1,
-          [`GET ${apiHost}/models/${model_name} version created_at`]: (r) =>
-          r.json().model.model_versions[0].created_at !== undefined,
-          [`GET ${apiHost}/models/${model_name} version updated_at`]: (r) =>
-          r.json().model.model_versions[0].updated_at !== undefined,
-          [`GET ${apiHost}/models/${model_name} version status`]: (r) =>
-          r.json().model.model_versions[0].status === "STATUS_OFFLINE",
-          [`GET ${apiHost}/models/${model_name} id`]: (r) =>
+          [`GET /models/${model_name} versions`]: (r) =>
+          r.json().model.modelVersions.length === 1,
+          [`GET /models/${model_name} version created_at`]: (r) =>
+          r.json().model.modelVersions[0].createdAt !== undefined,
+          [`GET /models/${model_name} version updated_at`]: (r) =>
+          r.json().model.modelVersions[0].updatedAt !== undefined,
+          [`GET /models/${model_name} version status`]: (r) =>
+          r.json().model.modelVersions[0].status === "STATUS_OFFLINE",
+          [`GET /models/${model_name} id`]: (r) =>
           r.json().model.id !== undefined,
-          [`GET ${apiHost}/models/${model_name} full_Name`]: (r) =>
-          r.json().model.full_name === `local-user/${model_name}`,
+          [`GET /models/${model_name} full_Name`]: (r) =>
+          r.json().model.fullName === `local-user/${model_name}`,
       });
 
       // clean up
@@ -758,34 +760,34 @@ export default function (data) {
         "POST /models/upload (multipart) det response Status": (r) =>
           r.status === 200,
           "POST /models/upload (multipart) task det response Name": (r) =>
-          r.json().Name !== undefined,
+          r.json().model.name !== undefined,
           "POST /models/upload (multipart) task det response FullName": (r) =>
-          r.json().FullName !== undefined,
+          r.json().model.fullName !== undefined,
           "POST /models/upload (multipart) task det response task": (r) =>
-          r.json().Task === "TASK_DETECTION",
+          r.json().model.task === "TASK_DETECTION",
           "POST /models/upload (multipart) task det response Versions": (r) =>
-          r.json().Versions.length === 1,
+          r.json().model.modelVersions.length === 1,
       });
 
       check(http.get(`${apiHost}/models`, {
         headers: genHeader(`application/json`),
       }), {
-        [`GET ${apiHost}/models response Status`]: (r) =>
+        [`GET /models response Status`]: (r) =>
           r.status === 200,
-          [`GET ${apiHost}/models cv_task`]: (r) =>
+          [`GET /models task`]: (r) =>
           r.json().models[0].task !== undefined,
-          [`GET ${apiHost}/models versions`]: (r) =>
-          r.json().models[0].model_versions.length > 0,
-          [`GET ${apiHost}/models version created_at`]: (r) =>
-          r.json().models[0].model_versions[0].created_at !== undefined,
-          [`GET ${apiHost}/models version updated_at`]: (r) =>
-          r.json().models[0].model_versions[0].updated_at !== undefined,
-          [`GET ${apiHost}/models version status`]: (r) =>
-          r.json().models[0].model_versions[0].status !== undefined,
-          [`GET ${apiHost}/models id`]: (r) =>
+          [`GET /models versions`]: (r) =>
+          r.json().models[0].modelVersions.length > 0,
+          [`GET /models version created_at`]: (r) =>
+          r.json().models[0].modelVersions[0].createdAt !== undefined,
+          [`GET /models version updated_at`]: (r) =>
+          r.json().models[0].modelVersions[0].updatedAt !== undefined,
+          [`GET /models version status`]: (r) =>
+          r.json().models[0].modelVersions[0].status !== undefined,
+          [`GET /models id`]: (r) =>
           r.json().models[0].id !== undefined,
-          [`GET ${apiHost}/models full_Name`]: (r) =>
-          r.json().models[0].full_name !== undefined,
+          [`GET /models full_Name`]: (r) =>
+          r.json().models[0].fullName !== undefined,
       });
 
       // clean up
@@ -814,16 +816,16 @@ export default function (data) {
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
         headers: genHeader(`multipart/form-data; boundary=${fd_cls.boundary}`),
       }), {
-        "POST /models (multipart) cls response Status": (r) =>
+        "POST /models/upload (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
           "POST /models (multipart) task cls response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task cls response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task cls response task": (r) =>
-          r.json().Task === "TASK_CLASSIFICATION",
-          "POST /models (multipart) task cls response Versions": (r) =>
-          r.json().Versions.length === 1,
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task cls response task": (r) =>
+          r.json().model.task === "TASK_CLASSIFICATION",
+          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          r.json().model.modelVersions.length === 1,
       });
 
       check(http.request("POST", `${apiHost}/models/upload`, fd_cls.body(), {
@@ -831,14 +833,14 @@ export default function (data) {
       }), {
         "POST /models (multipart) cls response Status": (r) =>
           r.status === 200, // TODO: update status to 201
-          "POST /models (multipart) task cls response Name": (r) =>
-          r.json().Name !== undefined,
-          "POST /models (multipart) task cls response FullName": (r) =>
-          r.json().FullName !== undefined,
-          "POST /models (multipart) task cls response task": (r) =>
-          r.json().Task === "TASK_CLASSIFICATION",
-          "POST /models (multipart) task cls response Versions": (r) =>
-          r.json().Versions.length === 2,
+          "POST /models/upload (multipart) task cls response Name": (r) =>
+          r.json().model.name !== undefined,
+          "POST /models/upload (multipart) task cls response FullName": (r) =>
+          r.json().model.fullName !== undefined,
+          "POST /models/upload (multipart) task cls response task": (r) =>
+          r.json().model.task === "TASK_CLASSIFICATION",
+          "POST /models/upload (multipart) task cls response Versions": (r) =>
+          r.json().model.modelVersions.length === 2,
       });
 
       let new_description = randomString(20)
@@ -848,20 +850,20 @@ export default function (data) {
       check(http.patch(`${apiHost}/models/${model_name}/versions/1`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response status`]: (r) =>
+        [`PATCH /models/${model_name}/versions/1 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response version`]: (r) =>
-          r.json().model_version.version !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
-          r.json().model_version.model_id !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response description`]: (r) =>
-          r.json().model_version.description === new_description,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
-          r.json().model_version.created_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
-          r.json().model_version.updated_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
-          r.json().model_version.status !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response version`]: (r) =>
+          r.json().modelVersion.version !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response model_id`]: (r) =>
+          r.json().modelVersion.modelId !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response description`]: (r) =>
+          r.json().modelVersion.description === new_description,
+          [`PATCH /models/${model_name}/versions/1 online task cls response created_at`]: (r) =>
+          r.json().modelVersion.createdAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response updated_at`]: (r) =>
+          r.json().modelVersion.updatedAt !== undefined,
+          [`PATCH /models/${model_name}/versions/1 online task cls response model version status`]: (r) =>
+          r.json().modelVersion.status !== undefined,
       });
 
       let new_description2 = randomString(20)
@@ -871,20 +873,20 @@ export default function (data) {
       check(http.patch(`${apiHost}/models/${model_name}/versions/2`, payload, {
         headers: genHeader(`application/json`),
       }), {
-        [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response status`]: (r) =>
+        [`PATCH /models/${model_name}/versions/2 online task cls response status`]: (r) =>
           r.status === 200, // TODO: update status to 201
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response version`]: (r) =>
-          r.json().model_version.version !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response model_id`]: (r) =>
-          r.json().model_version.model_id !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response description`]: (r) =>
-          r.json().model_version.description === new_description2,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response created_at`]: (r) =>
-          r.json().model_version.created_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response updated_at`]: (r) =>
-          r.json().model_version.updated_at !== undefined,
-          [`PATCH ${apiHost}/models/${model_name}/versions/2 online task cls response model version status`]: (r) =>
-          r.json().model_version.status !== undefined,
+          [`PATCH /models/${model_name}/versions/2 online task cls response version`]: (r) =>
+          r.json().modelVersion.version !== undefined,
+          [`PATCH /models/${model_name}/versions/2 online task cls response model_id`]: (r) =>
+          r.json().modelVersion.modelId !== undefined,
+          [`PATCH /models/${model_name}/versions/2 online task cls response description`]: (r) =>
+          r.json().modelVersion.description === new_description2,
+          [`PATCH /models/${model_name}/versions/2 online task cls response created_at`]: (r) =>
+          r.json().modelVersion.createdAt !== undefined,
+          [`PATCH /models/${model_name}/versions/2 online task cls response updated_at`]: (r) =>
+          r.json().modelVersion.updatedAt !== undefined,
+          [`PATCH /models/${model_name}/versions/2 online task cls response model version status`]: (r) =>
+          r.json().modelVersion.status !== undefined,
       });
 
       // clean up


### PR DESCRIPTION
Because

- Protobuf is refactored for simplifying output and updating the patch method

This commit

- Update example-go for model
- Update integration for model
