### PR TITLE
chore(mgmt-backend): add mgmt backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL:=help
 
-INSTILL_SERVICES := pipeline_backend_migrate pipeline_backend model_backend_migrate model_backend triton_conda_env
+INSTILL_SERVICES := mgmt_backend mgmt_backend_migrate mgmt_backend_init pipeline_backend_migrate pipeline_backend model_backend_migrate model_backend triton_conda_env
 3RD_PARTY_SERVICES := triton_server pg_sql temporal temporal_admin_tools temporal_web redis redoc_openapi
 ALL_SERVICES := ${INSTILL_SERVICES} ${3RD_PARTY_SERVICES}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,11 +90,11 @@ services:
       CFG_DATABASE_PASSWORD: password
       CFG_DATABASE_HOST: pg_sql
       CFG_DATABASE_PORT: 5432
-      CFG_SERVER_PORT: 8445
+      CFG_SERVER_PORT: 8083
       CFG_TRITONSERVER_GRPCURI: triton-server:8001
       CFG_TRITONSERVER_MODELSTORE: /model-repository
     ports:
-      - 8445:8445
+      - 8083:8083
     volumes:
       - model_repository:/model-repository
     depends_on:
@@ -122,13 +122,13 @@ services:
     image: instill/pipeline-backend:v0.3.1-alpha
     restart: unless-stopped
     environment:
-      CFG_SERVER_PORT: 8446
+      CFG_SERVER_PORT: 8081
       CFG_DATABASE_USERNAME: postgres
       CFG_DATABASE_PASSWORD: password
       CFG_DATABASE_HOST: pg_sql
       CFG_DATABASE_PORT: 5432
     ports:
-      - 8446:8446
+      - 8081:8081
     volumes:
       - ./backends/pipeline-backend/config:/pipeline-backend/configs
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,49 @@ services:
     depends_on:
       - temporal
 
+  mgmt_backend_migrate:
+    container_name: mgmt-backend-migrate
+    image: instill/mgmt-backend:v0.1.0-alpha
+    restart: on-failure
+    environment:
+      CFG_DATABASE_USERNAME: postgres
+      CFG_DATABASE_PASSWORD: password
+      CFG_DATABASE_HOST: pg_sql
+      CFG_DATABASE_PORT: 5432
+    entrypoint: ./mgmt-backend-migrate
+    depends_on:
+      pg_sql:
+        condition: service_healthy
+
+  mgmt_backend_init:
+    container_name: mgmt-backend-init
+    image: instill/mgmt-backend:v0.1.0-alpha
+    restart: on-failure
+    environment:
+      CFG_SERVER_PORT: 8080
+      CFG_DATABASE_USERNAME: postgres
+      CFG_DATABASE_PASSWORD: password
+      CFG_DATABASE_HOST: pg_sql
+      CFG_DATABASE_PORT: 5432
+    entrypoint: ./mgmt-backend-init
+    depends_on:
+      - mgmt_backend_migrate
+
+  mgmt_backend:
+    container_name: mgmt-backend
+    image: instill/mgmt-backend:v0.1.0-alpha
+    restart: unless-stopped
+    environment:
+      CFG_SERVER_PORT: 8080
+      CFG_DATABASE_USERNAME: postgres
+      CFG_DATABASE_PASSWORD: password
+      CFG_DATABASE_HOST: pg_sql
+      CFG_DATABASE_PORT: 5432
+    ports:
+      - 8080:8080
+    depends_on:
+      - mgmt_backend_migrate
+
   model_backend_migrate:
     container_name: model-backend-migrate
     image: instill/model-backend:v0.3.2-alpha


### PR DESCRIPTION
Because

- we want to manage user account

This commit

- add `mgmt-backend` for user management
- refactor backend ports
  - mgmt-backend: 8080
  - pipeline-backend: 8081
  - model-backend: 8083
