### PR TITLE
fix: fix OpenAPI swagger service

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -299,9 +299,8 @@ services:
 
   redoc_openapi:
     container_name: redoc-openapi
-    image: volbrene/redoc:1.2.0
+    image: redocly/redoc:v2.0.0-rc.70
     environment:
-      - 'URLS=[{url: ''https://raw.githubusercontent.com/instill-ai/protobufs/main/instill/pipeline/v1alpha/pipeline.swagger.json'', name: ''Pipeline''},{url: ''https://raw.githubusercontent.com/instill-ai/protobufs/main/instill/model/v1alpha/model.swagger.json'', name: ''Model''}]'
-      - PAGE_TITLE=Instill AI - API Reference
+      - SPEC_URL=https://raw.githubusercontent.com/instill-ai/protobufs/main/openapiv2/openapiv2.swagger.yaml
     ports:
       - 3000:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,9 +277,8 @@ services:
 
   redoc_openapi:
     container_name: redoc-openapi
-    image: volbrene/redoc:1.2.0
+    image: redocly/redoc:v2.0.0-rc.70
     environment:
-      - 'URLS=[{url: ''https://raw.githubusercontent.com/instill-ai/protobufs/main/instill/pipeline/v1alpha/pipeline.swagger.json'', name: ''Pipeline''},{url: ''https://raw.githubusercontent.com/instill-ai/protobufs/main/instill/model/v1alpha/model.swagger.json'', name: ''Model''}]'
-      - PAGE_TITLE=Instill AI - API Reference
+      - SPEC_URL=https://raw.githubusercontent.com/instill-ai/protobufs/main/openapiv2/openapiv2.swagger.yaml
     ports:
       - 3000:80


### PR DESCRIPTION
Because

- Instead of one for each backend, OpenAPI is [a single merged file](https://github.com/instill-ai/protobufs/blob/main/openapiv2/openapiv2.swagger.yaml)

This commit

- use Redocly official image
- render the single OpenAPI Swagger YAML
