### PR TITLE
feat: add console e2e test into vdp

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ DOCKER_BUILDKIT=1
 COMPOSE_DOCKER_CLI_BUILD=1
 
 # usage collection flag
-DISABLEUSAGE=false
+DISABLEUSAGE=true
 
 # pipeline-backend
 PIPELINE_BACKEND_VERSION=0.8.0-alpha

--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ DOCKER_BUILDKIT=1
 COMPOSE_DOCKER_CLI_BUILD=1
 
 # usage collection flag
-DISABLEUSAGE=true
+DISABLEUSAGE=false
 
 # pipeline-backend
 PIPELINE_BACKEND_VERSION=0.8.0-alpha
@@ -64,3 +64,8 @@ TEMPORAL_UI_PORT=8088
 REDOC_OPENAPI_VERSION=v2.0.0-rc.70
 REDOC_OPENAPI_HOST=redoc-openapi
 REDOC_OPENAPI_PORT=3001
+
+# This flag is used for integration test in which dummy model is used instead of pulling model from GitHub, HuggingFace or ArtiVC. 
+# The reason is reducing the impact of network trouble during integration test
+# The default value is alway false, only set when running `make integration-test`
+ITMODE=false

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ doc:						## Run Redoc for OpenAPI spec at http://localhost:3001
 .PHONY: integration-test
 integration-test:			## Run integration test for all dev repositories
 	@make build PROFILE=all
-	sed 's/CFG_SERVER_PORT: 8083/CFG_SERVER_PORT: 8083\n      CFG_SERVER_ITMODE: "true"/g' docker-compose-dev.yml > /tmp/docker-compose-integration-test.yml
+	@sed 's/CFG_SERVER_PORT: 8083/CFG_SERVER_PORT: 8083\n      CFG_SERVER_ITMODE: "true"/g' docker-compose-dev.yml > /tmp/docker-compose-integration-test.yml
 	COMPOSE_PROFILES=all docker-compose -f /tmp/docker-compose-integration-test.yml up -d
 	@cd dev/console && npm install && npx playwright install && npx playwright test
 	@cd dev/pipeline-backend && HOSTNAME=localhost make integration-test
@@ -98,6 +98,7 @@ integration-test:			## Run integration test for all dev repositories
 	@cd dev/model-backend && HOSTNAME=localhost make integration-test
 	@cd dev/mgmt-backend && HOSTNAME=localhost make integration-test
 	@make down
+	@rm /tmp/docker-compose-integration-test.yml
 
 .PHONY: help
 help:       	## Show this help

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ doc:						## Run Redoc for OpenAPI spec at http://localhost:3001
 .PHONY: integration-test
 integration-test:			## Run integration test for all dev repositories
 	@make build PROFILE=all
-	@make dev PROFILE=all
+	sed 's/CFG_SERVER_PORT: 8083/CFG_SERVER_PORT: 8083\n      CFG_SERVER_ITMODE: "true"/g' docker-compose-dev.yml > /tmp/docker-compose-integration-test.yml
+	COMPOSE_PROFILES=all docker-compose -f /tmp/docker-compose-integration-test.yml up -d
 	@cd dev/console && npm install && npx playwright install && npx playwright test
 	@cd dev/pipeline-backend && HOSTNAME=localhost make integration-test
 	@cd dev/connector-backend && HOSTNAME=localhost make integration-test

--- a/Makefile
+++ b/Makefile
@@ -90,15 +90,13 @@ doc:						## Run Redoc for OpenAPI spec at http://localhost:3001
 .PHONY: integration-test
 integration-test:			## Run integration test for all dev repositories
 	@make build PROFILE=all
-	@sed 's/CFG_SERVER_PORT: 8083/CFG_SERVER_PORT: 8083\n      CFG_SERVER_ITMODE: "true"/g' docker-compose-dev.yml > /tmp/docker-compose-integration-test.yml
-	COMPOSE_PROFILES=all docker-compose -f /tmp/docker-compose-integration-test.yml up -d
+	@make dev PROFILE=all ITMODE=true
 	@cd dev/console && npm install && npx playwright install && npx playwright test
 	@cd dev/pipeline-backend && HOSTNAME=localhost make integration-test
 	@cd dev/connector-backend && HOSTNAME=localhost make integration-test
 	@cd dev/model-backend && HOSTNAME=localhost make integration-test
 	@cd dev/mgmt-backend && HOSTNAME=localhost make integration-test
 	@make down
-	@rm /tmp/docker-compose-integration-test.yml
 
 .PHONY: help
 help:       	## Show this help

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ doc:						## Run Redoc for OpenAPI spec at http://localhost:3001
 integration-test:			## Run integration test for all dev repositories
 	@make build PROFILE=all
 	@make dev PROFILE=all
+	@cd dev/console && npm install && npx playwright install && npx playwright test
 	@cd dev/pipeline-backend && HOSTNAME=localhost make integration-test
 	@cd dev/connector-backend && HOSTNAME=localhost make integration-test
 	@cd dev/model-backend && HOSTNAME=localhost make integration-test

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -388,7 +388,7 @@ services:
     environment:
       NVIDIA_VISIBLE_DEVICES: 0
       LD_PRELOAD: /opt/tritonserver/lib/libgomp-d22c30c5.so.1
-    command: tritonserver --model-store=/model-repository --model-control-mode=explicit --allow-http=true --strict-model-config=false --log-verbose=1
+    command: tritonserver --model-store=/model-repository --model-control-mode=explicit --allow-http=true --strict-model-config=false
     ports:
       - ${TRITON_SERVER_PORT}:8001
     volumes:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -258,6 +258,7 @@ services:
     environment:
       CFG_SERVER_PORT: 8083
       CFG_SERVER_DEBUG: "true"
+      CFG_SERVER_ITMODE: ${ITMODE}
       CFG_SERVER_DISABLEUSAGE: ${DISABLEUSAGE}
       CFG_SERVER_EDITION: local-ce:latest
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}


### PR DESCRIPTION
Because

- The console integration test is ready

This commit

- add console e2e test into vdp
- update ITMODE=true when running integration-test. When the flag ITMODE is enabled, the integration-test use dummy models instead of pulling from GitHub, HuggingFace, or ArtiVC to reduce the impact of the internet connection.

co-author: @Phelan164 
