### PR TITLE
chore: add protocol of instance segmentation task

### DIFF
--- a/protocol/vdp_protocol.yaml
+++ b/protocol/vdp_protocol.yaml
@@ -15,6 +15,8 @@ anyOf:
   - required:
       - ocr
   - required:
+      - instance_segmentation      
+  - required:
       - unspecified
 properties:
   classification:
@@ -29,6 +31,9 @@ properties:
   ocr:
     description: "Detect, localise and recognise texts"
     "$ref": "#/definitions/Ocr"
+  instance_segmentation:
+    description: "Detect and delineate each distinct object of interest appearing in an image"
+    "$ref": "#/definitions/InstanceSegmentation"    
   unspecified:
     description: "Unspecified task with output in the free form"
     "$ref": "#/definitions/Unspecified"
@@ -131,6 +136,34 @@ definitions:
             score:
               description: "The confidence score of the predicted object"
               type: number
+  InstanceSegmentation:
+    type: object
+    additionalProperties: false
+    required:
+      - objects
+    properties:
+      objects:
+        description: "A list of detected instance bounding boxes"
+        type: array
+        items:
+          type: object
+          required:
+            - rle
+            - bounding_box
+            - label
+            - score
+          properties:
+            rle:
+              description: RLE of instance mask
+              type: array              
+            bounding_box:
+              "$ref": "#/definitions/BoundingBox"
+            label:
+              description: "Label text string recognised per bounding box in the `bounding_boxes`"
+              type: string
+            score:
+              description: "The confidence score of the predicted instance object"
+              type: number              
   Unspecified:
     type: object
     additionalProperties: false

--- a/protocol/vdp_protocol.yaml
+++ b/protocol/vdp_protocol.yaml
@@ -154,7 +154,7 @@ definitions:
             - score
           properties:
             rle:
-              description: RLE of instance mask
+              description: Run Length Encoding (RLE) of instance mask within the bounding box
               type: array              
             bounding_box:
               "$ref": "#/definitions/BoundingBox"


### PR DESCRIPTION
Because

- support instance segmentation task in VDP

This commit

- add protocol of instance segmentation task
