### PR TITLE
chore(model): update RLE output format to string

### DIFF
--- a/protocol/vdp_protocol.yaml
+++ b/protocol/vdp_protocol.yaml
@@ -155,7 +155,7 @@ definitions:
           properties:
             rle:
               description: Run Length Encoding (RLE) of instance mask within the bounding box
-              type: array              
+              type: string              
             bounding_box:
               "$ref": "#/definitions/BoundingBox"
             label:


### PR DESCRIPTION
Because

- the length of RLEs are different between objects, so it could not broadcast in the Triton server output

This commit

- update RLE output format to string (example: [1, 3, 4] => "1,3,4")
- to decode RLE need to convert the string to an array
