### PR TITLE
chore: bump up backends and frontend

### DIFF
--- a/.env
+++ b/.env
@@ -9,22 +9,22 @@ COMPOSE_DOCKER_CLI_BUILD=1
 DISABLEUSAGE=false
 
 # pipeline-backend
-PIPELINE_BACKEND_VERSION=0.8.0-alpha
+PIPELINE_BACKEND_VERSION=0.9.2-alpha
 PIPELINE_BACKEND_HOST=pipeline-backend
 PIPELINE_BACKEND_PORT=8081
 
 # connector-backend
-CONNECTOR_BACKEND_VERSION=0.6.0-alpha
+CONNECTOR_BACKEND_VERSION=0.7.1-alpha
 CONNECTOR_BACKEND_HOST=connector-backend
 CONNECTOR_BACKEND_PORT=8082
 
 # model-backend
-MODEL_BACKEND_VERSION=0.8.1-alpha
+MODEL_BACKEND_VERSION=0.9.1-alpha
 MODEL_BACKEND_HOST=model-backend
 MODEL_BACKEND_PORT=8083
 
 # mgmt-backend
-MGMT_BACKEND_VERSION=0.2.6-alpha
+MGMT_BACKEND_VERSION=0.2.7-alpha
 MGMT_BACKEND_HOST=mgmt-backend
 MGMT_BACKEND_PORT=8084
 
@@ -37,7 +37,7 @@ TRITON_SERVER_PORT=8001
 TRITON_CONDA_ENV_VERSION=0.2.6-alpha
 
 # console
-CONSOLE_VERSION=0.12.0-alpha
+CONSOLE_VERSION=0.13.0-alpha
 CONSOLE_HOST=console
 CONSOLE_PORT=3000
 
@@ -65,7 +65,7 @@ REDOC_OPENAPI_VERSION=v2.0.0-rc.70
 REDOC_OPENAPI_HOST=redoc-openapi
 REDOC_OPENAPI_PORT=3001
 
-# This flag is used for integration test in which dummy model is used instead of pulling model from GitHub, HuggingFace or ArtiVC. 
+# This flag is used for integration test in which dummy model is used instead of pulling model from GitHub, HuggingFace or ArtiVC.
 # The reason is reducing the impact of network trouble during integration test
 # The default value is alway false, only set when running `make integration-test`
 ITMODE=false

--- a/examples/async/yolov7/main.py
+++ b/examples/async/yolov7/main.py
@@ -239,7 +239,7 @@ if __name__ ==  '__main__':
 
     print("\n=====Trigger {} pipeline to process images in '{}'\n".format(opt.pipeline, image_dir))
     for files in tqdm(img_batch):
-        resp = requests.post(f'http://{backend["pipeline"]}/{ver}/pipelines/{opt.pipeline}:trigger-multipart',
+        resp = requests.post(f'http://{backend["pipeline"]}/{ver}/pipelines/{opt.pipeline}/trigger-multipart',
                         files=[("file", (filename, open(join(image_dir, filename), 'rb'))) for filename in files])
         if resp.status_code == 200:
             data_mapping_indices += resp.json()['data_mapping_indices']

--- a/examples/streamlit/stomata/README.md
+++ b/examples/streamlit/stomata/README.md
@@ -8,8 +8,7 @@ Run VDP locally
 
 ```bash
 $ git clone https://github.com/instill-ai/vdp.git && cd vdp
-$ make build PROFILE=all
-$ make dev PROFILE=all
+$ make all
 ```
 
 If this is your first time setting up VDP, access the Console (http://localhost:3000) and you should see the onboarding page. Please enter your email and you are all set!

--- a/examples/streamlit/yolov7/main.py
+++ b/examples/streamlit/yolov7/main.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
 
     # Use image remote URL to fetch an image in input
     image_url = st.text_input(
-        label="Feed me with an image URL and press ENTER", value="https://artifacts.instill.tech/dog.jpg")
+        label="Feed me with an image URL and press ENTER", value="https://artifacts.instill.tech/imgs/dog.jpg")
 
     try:
         # Trigger VDP pipelines


### PR DESCRIPTION
Because

- we want to use the latest services

This commit

- bump pipeline-backend from `0.8.0-alpha` to `0.9.2-alpha`
- bump connector-backend from `0.6.0-alpha` to `0.7.1-alpha`
- bump model-backend from `0.8.1-alpha` to `0.9.1-alpha`
- bump mgmt-backend from `0.2.6-alpha` to `0.2.7-alpha`
- bump console from `0.12.0-alpha` to `0.13.0-alpha`
- update the examples
