### PR TITLE
chore(model): update model output protocol

### DIFF
--- a/protocol/vdp_protocol.yaml
+++ b/protocol/vdp_protocol.yaml
@@ -17,6 +17,8 @@ anyOf:
   - required:
       - instance_segmentation
   - required:
+      - semantic_segmentation      
+  - required:
       - unspecified
 properties:
   classification:
@@ -34,6 +36,9 @@ properties:
   instance_segmentation:
     description: "Detect and delineate each distinct object of interest appearing in an image"
     "$ref": "#/definitions/InstanceSegmentation"
+  semantic_segmentation:
+    description: "Label specific regions of an image according to what's being shown"
+    "$ref": "#/definitions/SemanticSegmentation"    
   unspecified:
     description: "Unspecified task with output in the free form"
     "$ref": "#/definitions/Unspecified"
@@ -150,7 +155,7 @@ definitions:
           required:
             - rle
             - bounding_box
-            - label
+            - category
             - score
           properties:
             rle:
@@ -158,12 +163,33 @@ definitions:
               type: string
             bounding_box:
               "$ref": "#/definitions/BoundingBox"
-            label:
-              description: "Label text string recognised per bounding box in the `bounding_boxes`"
+            category:
+              description: "Category text string recognised per bounding box in the `bounding_boxes`"
               type: string
             score:
               description: "The confidence score of the predicted instance object"
               type: number
+  SemanticSegmentation:
+    type: object
+    additionalProperties: false
+    required:
+      - stuffs
+    properties:
+      objects:
+        description: "A list of RLE binary masks"
+        type: array
+        items:
+          type: object
+          required:
+            - rle
+            - category
+          properties:
+            rle:
+              description: Run Length Encoding (RLE) of each stuff mask within the image
+              type: string
+            category:
+              description: "Category text string corresponding to each stuff mask"
+              type: string
   Unspecified:
     type: object
     additionalProperties: false


### PR DESCRIPTION
Because

- support semantic segmentation in the VDP task

This commit

- add semantic segmentation in `protocol/vdp_protocol.yaml`
- change `label` to `category` in instance segmentation for naming consistency
- close #163 
- close #164
