### PR TITLE
chore: update to Versatile Data Pipeline

### DIFF
--- a/.github/workflows/add-issue-to-prj.yml
+++ b/.github/workflows/add-issue-to-prj.yml
@@ -9,6 +9,6 @@ jobs:
   track_issue:
     uses: instill-ai/meta/.github/workflows/add-issue-to-prj.yml@main
     with:
-      project_number: 5 # Visual Data Preparation (VDP) project
+      project_number: 5 # Versatile Data Pipeline (VDP) project
     secrets:
       botGitHubToken: ${{ secrets.botGitHubToken }}

--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -9,6 +9,6 @@ jobs:
   track_pr:
     uses: instill-ai/meta/.github/workflows/add-pr-to-prj.yml@main
     with:
-      project_number: 5 # Visual Data Preparation (VDP) project
+      project_number: 5 # Versatile Data Pipeline (VDP) project
     secrets:
       botGitHubToken: ${{ secrets.botGitHubToken }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 - 🧁 **[Scalable API-first microservice design for great developer experience](https://www.instill.tech/docs/start-here/faq#tech)** - seamless integration to modern data stack at any scale
 
-- 🤠 **[Build for every AI and Data practitioner](https://www.instill.tech/docs/start-here/faq#essentials)** - The no-/low-code interface helps take off your AI Researcher/AI Engineer/Data Engineer/Data Scientist hat and *put on the all-rounder hat* to deliver more with VDP
+- 🤠 **[Built for every AI and Data practitioner](https://www.instill.tech/docs/start-here/faq#essentials)** - The no-/low-code interface helps take off your AI Researcher/AI Engineer/Data Engineer/Data Scientist hat and *put on the all-rounder hat* to deliver more with VDP
 
 ## Online demos
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img src="https://raw.githubusercontent.com/instill-ai/.github/main/img/vdp.svg" alt="Visual Data Preparation: open-source visual data ETL">
+  <img src="https://raw.githubusercontent.com/instill-ai/.github/main/img/vdp.svg" alt="Versatile Data Pipeline: open-source unstructured data ETL">
 </h1>
 
 <h4 align="center">
@@ -15,7 +15,7 @@
 
 ---
 
-# Visual Data Preparation (VDP)  &nbsp; [![Twitter URL](https://img.shields.io/twitter/url?logo=twitter&style=social&url=https%3A%2F%2Fgithub.com%2Finstill-ai%2Fvdp)](https://twitter.com/intent/tweet?url=https%3A%2F%2Fgithub.com%2Finstill-ai%2Fvdp&via=instill_tech&text=Build%20end-to-end%20visual%20data%20processing%20pipelines%20with%20VDP%2C%2010x%20faster.&hashtags=ETL%2Cvdp%2Cdata%2Cai%2Cml%2Copensource)
+# Versatile Data Pipeline (VDP)  &nbsp; [![Twitter URL](https://img.shields.io/twitter/url?logo=twitter&style=social&url=https%3A%2F%2Fgithub.com%2Finstill-ai%2Fvdp)](https://twitter.com/intent/tweet?url=https%3A%2F%2Fgithub.com%2Finstill-ai%2Fvdp&via=instill_tech&text=Build%20end-to-end%20unstructured%20data%20processing%20pipelines%20with%20VDP%2C%2010x%20faster.&hashtags=ETL%2Cvdp%2Cdata%2Cai%2Cml%2Copensource)
 
 [![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/instill-ai/vdp?&label=Release&color=blue&include_prereleases&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTQgOEg3VjRIMjNWMTdIMjFDMjEgMTguNjYgMTkuNjYgMjAgMTggMjBDMTYuMzQgMjAgMTUgMTguNjYgMTUgMTdIOUM5IDE4LjY2IDcuNjYgMjAgNiAyMEM0LjM0IDIwIDMgMTguNjYgMyAxN0gxVjEyTDQgOFpNMTggMThDMTguNTUgMTggMTkgMTcuNTUgMTkgMTdDMTkgMTYuNDUgMTguNTUgMTYgMTggMTZDMTcuNDUgMTYgMTcgMTYuNDUgMTcgMTdDMTcgMTcuNTUgMTcuNDUgMTggMTggMThaTTQuNSA5LjVMMi41NCAxMkg3VjkuNUg0LjVaTTYgMThDNi41NSAxOCA3IDE3LjU1IDcgMTdDNyAxNi40NSA2LjU1IDE2IDYgMTZDNS40NSAxNiA1IDE2LjQ1IDUgMTdDNSAxNy41NSA1LjQ1IDE4IDYgMThaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K)](https://github.com/instill-ai/vdp/releases)
 [![License Apache-2.0](https://img.shields.io/crates/l/ap?label=License&color=blue&logo=apache)](https://github.com/instill-ai/vdp/blob/main/LICENSE)
@@ -25,25 +25,25 @@
 [![Documentation deployment workflow](https://img.shields.io/github/actions/workflow/status/instill-ai/instill.tech/release.yml?branch=main&label=Docs&logoColor=fff&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTQiIHZpZXdCb3g9IjAgMCAxNiAxNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wIDAuNzUwMDA0QzAgMC41NTEwOTEgMC4wNzkwMTc2IDAuMzYwMzI2IDAuMjE5NjcgMC4yMTk2NzRDMC4zNjAzMjIgMC4wNzkwMjEzIDAuNTUxMDg4IDMuNjgxOTFlLTA2IDAuNzUgMy42ODE5MWUtMDZINS4wMDNDNi4yMyAzLjY4MTkxZS0wNiA3LjMyIDAuNTkwMDA0IDguMDAzIDEuNTAxQzguMzUyMTggMS4wMzQzMyA4LjgwNTQ4IDAuNjU1NjI3IDkuMzI2ODMgMC4zOTUwNDJDOS44NDgxNyAwLjEzNDQ1NiAxMC40MjMyIC0wLjAwMDgxMzY0NiAxMS4wMDYgMy42ODE5MWUtMDZIMTUuMjUxQzE1LjQ0OTkgMy42ODE5MWUtMDYgMTUuNjQwNyAwLjA3OTAyMTMgMTUuNzgxMyAwLjIxOTY3NEMxNS45MjIgMC4zNjAzMjYgMTYuMDAxIDAuNTUxMDkxIDE2LjAwMSAwLjc1MDAwNFYxMS4yNUMxNi4wMDEgMTEuNDQ4OSAxNS45MjIgMTEuNjM5NyAxNS43ODEzIDExLjc4MDNDMTUuNjQwNyAxMS45MjEgMTUuNDQ5OSAxMiAxNS4yNTEgMTJIMTAuNzQ0QzEwLjQ0ODUgMTIgMTAuMTU1OSAxMi4wNTgyIDkuODgyOTYgMTIuMTcxM0M5LjYwOTk3IDEyLjI4NDMgOS4zNjE5MyAxMi40NTAxIDkuMTUzIDEyLjY1OUw4LjUzMSAxMy4yOEM4LjM5MDM3IDEzLjQyMDUgOC4xOTk3NSAxMy40OTkzIDguMDAxIDEzLjQ5OTNDNy44MDIyNSAxMy40OTkzIDcuNjExNjMgMTMuNDIwNSA3LjQ3MSAxMy4yOEw2Ljg0OSAxMi42NTlDNi42NDAwNyAxMi40NTAxIDYuMzkyMDMgMTIuMjg0MyA2LjExOTA0IDEyLjE3MTNDNS44NDYwNiAxMi4wNTgyIDUuNTUzNDggMTIgNS4yNTggMTJIMC43NUMwLjU1MTA4OCAxMiAwLjM2MDMyMiAxMS45MjEgMC4yMTk2NyAxMS43ODAzQzAuMDc5MDE3NiAxMS42Mzk3IDAgMTEuNDQ4OSAwIDExLjI1TDAgMC43NTAwMDRaTTguNzU1IDMuNzVDOC43NTUgMy4xNTMyNyA4Ljk5MjA1IDIuNTgwOTcgOS40MTQwMSAyLjE1OTAxQzkuODM1OTcgMS43MzcwNiAxMC40MDgzIDEuNSAxMS4wMDUgMS41SDE0LjVWMTAuNUgxMC43NDNDMTAuMDMzIDEwLjUgOS4zNDMgMTAuNzAxIDguNzUxIDExLjA3Mkw4Ljc1NSAzLjc1VjMuNzVaTTcuMjUxIDExLjA3NEw3LjI1NSA2LjAwMUw3LjI1MyAzLjc0OEM3LjI1MjQ3IDMuMTUxNjEgNy4wMTUxOCAyLjU3OTgzIDYuNTkzMjggMi4xNTgzMUM2LjE3MTM4IDEuNzM2NzggNS41OTkzOSAxLjUgNS4wMDMgMS41SDEuNVYxMC41SDUuMjU3QzUuOTYyNDIgMTAuNSA2LjY1MzU1IDEwLjY5ODkgNy4yNTEgMTEuMDc0VjExLjA3NFoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=)](https://github.com/instill-ai/instill.tech/actions/workflows/deploy-prod.yml)
 
 
-**Visual Data Preparation (VDP)** is an open-source visual data ETL tool to streamline the end-to-end visual data processing pipeline:
+**Versatile Data Pipeline (VDP)** is an open-source unstructured data ETL tool to streamline the end-to-end unstructured data processing pipeline:
 
-- **Extract** unstructured visual data from pre-built data sources such as cloud/on-prem storage, or IoT devices
+- **Extract** unstructured data from pre-built data sources such as cloud/on-prem storage, or IoT devices
 
-- **Transform** it into analysable structured data by Vision AI models
+- **Transform** it into analysable or meaningful data representations by AI models
 
 - **Load** the transformed data into warehouses, applications, or other destinations
 
-![VDO Concept](https://artifacts.instill.tech/imgs/vdp-concept.png?id=1)
+![VDP Concept](https://artifacts.instill.tech/imgs/vdp-concept.png?id=1)
 
 ## Highlights
 
-- 🚀 **[The fastest way to build end-to-end visual data pipelines](https://www.instill.tech/docs/core-concepts/pipeline)** - building a pipeline is like assembling LEGO blocks
+- 🚀 **[The fastest way to build end-to-end unstructured data pipelines](https://www.instill.tech/docs/core-concepts/pipeline)** - building a pipeline is like assembling LEGO blocks
 
 - ⚡️ **[High-performing backends](https://www.instill.tech/docs/prepare-models/overview)** implemented in Go with Triton Inference Server for unleashing the full power of NVIDIA GPU architecture (e.g., concurrency, scheduler, batcher) supporting TensorRT, PyTorch, TensorFlow, ONNX, Python and more.
 
 - 🖱️ **[One-click import & deploy ML/DL models](https://www.instill.tech/docs/import-models/overview)** from GitHub, Hugging Face or cloud storage managed by version control tools like DVC or ArtiVC
 
-- 📦 **[Standardised CV Task](https://www.instill.tech/docs/core-concepts/cv-task)** structured output formats to streamline with data warehouse
+- 📦 **[Standardised AI Task](https://www.instill.tech/docs/core-concepts/ai-task)** output formats to streamline data integration or analysis
 
 - 🔌 **[Pre-built ETL data connectors](https://www.instill.tech/docs/core-concepts/connector)** for extensive data access integrated with Airbyte
 
@@ -51,7 +51,7 @@
 
 - 🧁 **[Scalable API-first microservice design for great developer experience](https://www.instill.tech/docs/start-here/faq#tech)** - seamless integration to modern data stack at any scale
 
-- 🤠 **[Build for every Vision AI and Data practitioner](https://www.instill.tech/docs/start-here/faq#essentials)** - The no-/low-code interface helps take off your AI Researcher/AI Engineer/Data Engineer/Data Scientist hat and *put on the all-rounder hat* to deliver more with VDP
+- 🤠 **[Build for every AI and Data practitioner](https://www.instill.tech/docs/start-here/faq#essentials)** - The no-/low-code interface helps take off your AI Researcher/AI Engineer/Data Engineer/Data Scientist hat and *put on the all-rounder hat* to deliver more with VDP
 
 ## Online demos
 
@@ -107,7 +107,7 @@ VDP is built with open heart and we expect VDP to be exposed to more MLOps integ
 
 - [Airbyte](https://github.com/airbytehq/airbyte) for abundant destination connectors
 
-We hope VDP can also enrich the open-source communities in a way to bring more practical use cases in unstructured visual data processing.
+We hope VDP can also enrich the open-source communities in a way to bring more practical use cases in unstructured data processing.
 
 ## Documentation
 

--- a/examples/streamlit/stomata/README.md
+++ b/examples/streamlit/stomata/README.md
@@ -13,7 +13,7 @@ $ make all
 
 If this is your first time setting up VDP, access the Console (http://localhost:3000) and you should see the onboarding page. Please enter your email and you are all set!
 
-After onboarding, you will be redirected to the **Pipeline** page on the left sidebar, where you can build your first VDP pipeline by clicking **Set up your first pipeline** and forever change the way you approach visual data processing workflow development.
+After onboarding, you will be redirected to the **Pipeline** page on the left sidebar, where you can build your first VDP pipeline by clicking **Set up your first pipeline** and forever change the way you approach unstructured data processing workflow development.
 
 #### Create a SYNC pipeline `stomata`
 

--- a/examples/streamlit/stomata/streamlit_main.py
+++ b/examples/streamlit/stomata/streamlit_main.py
@@ -75,11 +75,11 @@ def display_intro_markdown(pipeline_id="stomata"):
 
     # 🥦 Identify stomata by triggering VDP pipeline
 
-    [Visual Data Preparation (VDP)](https://github.com/instill-ai/vdp) is an open-source visual data ETL tool to streamline the end-to-end visual data processing pipeline
+    [Versatile Data Pipeline (VDP)](https://github.com/instill-ai/vdp) is an open-source unstructured data ETL tool to streamline end-to-end unstructured data processing
 
-    - 🚀 The fastest way to build end-to-end visual data pipelines
+    - 🚀 The fastest way to build end-to-end unstructured data pipelines
     - 🖱️ One-click import & deploy ML/DL models
-    - 🤠 Build for every Vision AI and Data practitioner
+    - 🤠 Build for every AI and Data practitioner
 
     Give us a ⭐ on [![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/instill-ai/vdp) and join our [![Discord](https://img.shields.io/badge/Community-%237289DA.svg?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/sevxWsqpGh)
 
@@ -102,15 +102,15 @@ def display_vdp_markdown():
     vdp_markdown = """
     # What's cool about VDP?
 
-    A VDP pipeline unlocks the value of unstructured visual data:
+    A VDP pipeline unlocks the value of unstructured data:
 
-    1. **Extract** unstructured visual data from pre-built data sources such as cloud/on-prem storage, or IoT devices
+    1. **Extract** unstructured data from pre-built data sources such as cloud/on-prem storage, or IoT devices
 
-    2. **Transform** it into analysable structured data by Vision AI models
+    2. **Transform** it into meaningful data representations by AI models
 
     3. **Load** the transformed data into warehouses, applications, or other destinations
 
-    With the help of the VDP pipeline, you can start manipulating the data using other structured data tooling in the modern data stack.
+    With the help of the VDP pipeline, you can start manipulating the data using other data tooling in the modern data stack.
     """
     st.markdown(vdp_markdown)
 

--- a/examples/streamlit/stomata/streamlit_main.py
+++ b/examples/streamlit/stomata/streamlit_main.py
@@ -79,7 +79,7 @@ def display_intro_markdown(pipeline_id="stomata"):
 
     - 🚀 The fastest way to build end-to-end unstructured data pipelines
     - 🖱️ One-click import & deploy ML/DL models
-    - 🤠 Build for every AI and Data practitioner
+    - 🤠 Built for every AI and Data practitioner
 
     Give us a ⭐ on [![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/instill-ai/vdp) and join our [![Discord](https://img.shields.io/badge/Community-%237289DA.svg?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/sevxWsqpGh)
 

--- a/examples/streamlit/yolov7/main.py
+++ b/examples/streamlit/yolov7/main.py
@@ -87,7 +87,7 @@ def display_intro_markdown(demo_url="https://demo.instill.tech/yolov4-vs-yolov7"
 
     - 🚀 The fastest way to build end-to-end unstructured data pipelines
     - 🖱️ One-click import & deploy ML/DL models
-    - 🤠 Build for every AI and Data practitioner
+    - 🤠 Built for every AI and Data practitioner
 
     Give us a ⭐ on [![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/instill-ai/vdp) and join our [![Discord](https://img.shields.io/badge/Community-%237289DA.svg?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/sevxWsqpGh)
 

--- a/examples/streamlit/yolov7/main.py
+++ b/examples/streamlit/yolov7/main.py
@@ -83,11 +83,11 @@ def display_intro_markdown(demo_url="https://demo.instill.tech/yolov4-vs-yolov7"
     [![Facebook](https://img.shields.io/badge/Facebook-%231877F2.svg?style=for-the-badge&logo=Facebook&logoColor=white)](https://www.facebook.com/sharer/sharer.php?kid_directed_site=0&sdk=joey&u={}&display=popup&ref=plugin&src=share_button)
     [![LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/sharing/share-offsite/?url={})
 
-    [Visual Data Preparation (VDP)](https://github.com/instill-ai/vdp) is an open-source visual data ETL tool to streamline the end-to-end visual data processing pipeline
+    [Versatile Data Pipeline (VDP)](https://github.com/instill-ai/vdp) is an open-source unstructured data ETL tool to streamline end-to-end unstructured data processing
 
-    - 🚀 The fastest way to build end-to-end visual data pipelines
+    - 🚀 The fastest way to build end-to-end unstructured data pipelines
     - 🖱️ One-click import & deploy ML/DL models
-    - 🤠 Build for every Vision AI and Data practitioner
+    - 🤠 Build for every AI and Data practitioner
 
     Give us a ⭐ on [![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/instill-ai/vdp) and join our [![Discord](https://img.shields.io/badge/Community-%237289DA.svg?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/sevxWsqpGh)
 
@@ -112,15 +112,15 @@ def display_vdp_markdown():
     vdp_markdown = """
     # What's cool about VDP?
 
-    A VDP pipeline unlocks the value of unstructured visual data:
+    A VDP pipeline unlocks the value of unstructured data:
 
-    1. **Extract** unstructured visual data from pre-built data sources such as cloud/on-prem storage, or IoT devices
+    1. **Extract** unstructured data from pre-built data sources such as cloud/on-prem storage, or IoT devices
 
-    2. **Transform** it into analysable structured data by Vision AI models
+    2. **Transform** it into meaningful data representations by AI models
 
     3. **Load** the transformed data into warehouses, applications, or other destinations
 
-    With the help of the VDP pipeline, you can start manipulating the data using other structured data tooling in the modern data stack. The results of the above demo will be streamed to the destination data warehouse like:
+    With the help of the VDP pipeline, you can start manipulating the data using other data tooling in the modern data stack. The results of the above demo will be streamed to the destination data warehouse like:
     """
     st.markdown(vdp_markdown)
 


### PR DESCRIPTION
Because

- instead of Visual Data Preparation, VDP is _Versatile Data Pipeline_ now. We realise that as a general ETL infrastructure, VDP is capable of processing all kinds of unstructured data, and we should not limit its usage to only visual data. That's why we replace the word Visual with Versatile. Besides, the term Data Preparation is a bit misleading, users often think it has something to do with data labelling or cleaning. The term Data Pipeline is definitely more precise to capture the core concept of VDP.

This commit

- update to Versatile Data Pipeline
