### PR TITLE
chore: udpate temporal admin to create search attibutes

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -525,6 +525,7 @@ services:
     restart: unless-stopped
     environment:
       TEMPORAL_CLI_ADDRESS: ${TEMPORAL_HOST}:${TEMPORAL_PORT}
+    entrypoint: /bin/bash -c `tctl --auto_confirm admin cluster add-search-attributes --name Type --type Text --name ModelUID --type Text --name ModelInstanceUID --type Text --name Owner --type Text && tail -f /dev/null`
     depends_on:
       temporal:
         condition: service_healthy


### PR DESCRIPTION
Because

- model-backend create search attributes using DinD not straight forward for deployment

This commit

- move creating search attributes to temporal_admin_tool container
