### PR TITLE
chore: add Dockerfile for stomata example

### DIFF
--- a/.github/workflows/images-example.yml
+++ b/.github/workflows/images-example.yml
@@ -28,6 +28,8 @@ jobs:
               - 'examples/streamlit/yolov7/**'
             streamlit-instance-segmentation:
               - 'examples/streamlit/instance_segmentation/**'
+            streamlit-stomata:
+              - 'examples/streamlit/stomata/**'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -58,4 +60,15 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: instill/streamlit-instance-segmentation:latest
+          no-cache: true
+
+      # Run only if some file in 'examples/streamlit/yolov7' folder was changed
+      - name: Build and push (latest)
+        uses: docker/build-push-action@v3
+        if: steps.filter.outputs.streamlit-stomata == 'true'
+        with:
+          context: "{{defaultContext}}:examples/streamlit/stomata"
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: instill/streamlit-stomata:latest
           no-cache: true

--- a/examples/streamlit/instance_segmentation/README.md
+++ b/examples/streamlit/instance_segmentation/README.md
@@ -73,7 +73,7 @@ $ pip install -r requirements.txt
 #   --demo-url=< demo URL >
 #   --pipeline-backend-base-url=< pipeline backend base URL >
 #   --pipeline-id=< Pipeline ID >
-$ streamlit run main.py -- --pipeline-backend-base-url=http://localhost:8081 --pipeline-id=inst
+$ streamlit run main.py -- --pipeline-backend-base-url=http://localhost:8080 --pipeline-id=inst
 ```
 
 Now go to `http://localhost:8501/` 🎉
@@ -94,7 +94,7 @@ $ docker build -t streamlit-instance-segmentation .
 ```
 Run the Docker container and connect to VDP
 ```bash
-$ docker run -p 8501:8501 --network instill-network streamlit-instance-segmentation -- --pipeline-backend-base-url=http://pipeline-backend:8081 --pipeline-id=inst
+$ docker run -p 8501:8501 --network instill-network streamlit-instance-segmentation -- --pipeline-backend-base-url=http://api-gateway:8080 --pipeline-id=inst
 
 You can now view your Streamlit app in your browser.
 

--- a/examples/streamlit/instance_segmentation/main.py
+++ b/examples/streamlit/instance_segmentation/main.py
@@ -58,9 +58,11 @@ def trigger_pipeline(pipeline_backend_base_url: str, pipeline_id: str, image_url
 
     """
     body = {
-        "inputs": [
+        "task_inputs": [
             {
-                'image_url': image_url
+                "instance_segmentation": {
+                    'image_url': image_url
+                }
             }
         ]
     }
@@ -126,9 +128,11 @@ def display_trigger_request_code(pipeline_id):
         curl -X POST '{pipeline_backend_base_url}/pipelines/{pipeline_id}/trigger' \\
         --header 'Content-Type: application/json' \\
         --data-raw '{{
-            "inputs": [
+            "task_inputs": [
                 {{
-                    "image_url": "{image_url}"
+                    "instance_segmentation": {{
+                        "image_url": "{image_url}"
+                    }}
                 }}
             ]
         }}'

--- a/examples/streamlit/instance_segmentation/main.py
+++ b/examples/streamlit/instance_segmentation/main.py
@@ -139,7 +139,7 @@ def display_trigger_request_code(pipeline_id):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--pipeline-backend-base-url', type=str,
-                        default='http://localhost:8081', help='pipeline backend base URL')
+                        default='http://localhost:8080', help='pipeline backend base URL')
     parser.add_argument('--pipeline-id', type=str,
                         default='inst', help='Instance segmentation pipeline ID on VDP')
     opt = parser.parse_args()

--- a/examples/streamlit/stomata/Dockerfile
+++ b/examples/streamlit/stomata/Dockerfile
@@ -1,0 +1,14 @@
+FROM --platform=$BUILDPLATFORM python:3.8-slim
+EXPOSE 8501
+
+RUN apt-get update \
+    && apt-get install -y build-essential
+
+WORKDIR /app
+
+COPY requirements.txt ./requirements.txt
+RUN pip install -r requirements.txt
+
+
+COPY . .
+ENTRYPOINT ["streamlit", "run", "main.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/examples/streamlit/stomata/README.md
+++ b/examples/streamlit/stomata/README.md
@@ -73,8 +73,8 @@ $ pip install -r requirements.txt
 # Run the demo
 #   --demo-url=< demo URL >
 #   --pipeline-backend-base-url=< pipeline backend base URL >
-#   --stomata=< Stomata pipeline ID >
-$ streamlit run streamlit_main.py -- --pipeline-backend-base-url=http://localhost:8081 --stomata=stomata
+#   --pipeline-id=< Stomata pipeline ID >
+$ streamlit run main.py -- --pipeline-backend-base-url=http://localhost:8081 --pipeline-id=stomata
 ```
 
 Now go to `http://localhost:8501/` 🎉
@@ -86,3 +86,20 @@ To shut down all running services:
 ```
 $ make down
 ```
+
+## Deploy the demo using Docker
+
+Build a Docker image
+```bash
+$ docker build -t streamlit-stomata .
+```
+Run the Docker container and connect to VDP
+```bash
+$ docker run --rm --name streamlit-stomata -p 8501:8501 --network instill-network streamlit-stomata -- --pipeline-backend-base-url=http://api-gateway:8080 --pipeline-id=stomata
+
+You can now view your Streamlit app in your browser.
+
+  URL: http://0.0.0.0:8501
+
+```
+

--- a/examples/streamlit/stomata/README.md
+++ b/examples/streamlit/stomata/README.md
@@ -74,7 +74,7 @@ $ pip install -r requirements.txt
 #   --demo-url=< demo URL >
 #   --pipeline-backend-base-url=< pipeline backend base URL >
 #   --pipeline-id=< Stomata pipeline ID >
-$ streamlit run main.py -- --pipeline-backend-base-url=http://localhost:8081 --pipeline-id=stomata
+$ streamlit run main.py -- --pipeline-backend-base-url=http://localhost:8080 --pipeline-id=stomata
 ```
 
 Now go to `http://localhost:8501/` 🎉

--- a/examples/streamlit/stomata/main.py
+++ b/examples/streamlit/stomata/main.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--pipeline-backend-base-url', type=str,
                         default='http://localhost:8081', help='pipeline backend base URL')
-    parser.add_argument('--stomata', type=str,
+    parser.add_argument('--pipeline-id', type=str,
                         default='stomata', help='Stomata instance segmentation pipeline ID on VDP')
     opt = parser.parse_args()
     print(opt)
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     st.caption(filename)
 
     try:
-        pipeline_id = opt.stomata
+        pipeline_id = opt.pipeline_id
         pipeline_results = []
         display_trigger_request_code(pipeline_id, filename)
         # Trigger VDP pipelines

--- a/examples/streamlit/stomata/main.py
+++ b/examples/streamlit/stomata/main.py
@@ -128,7 +128,7 @@ def display_trigger_request_code(pipeline_id, filename):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--pipeline-backend-base-url', type=str,
-                        default='http://localhost:8081', help='pipeline backend base URL')
+                        default='http://localhost:8080', help='pipeline backend base URL')
     parser.add_argument('--pipeline-id', type=str,
                         default='stomata', help='Stomata instance segmentation pipeline ID on VDP')
     opt = parser.parse_args()

--- a/examples/streamlit/yolov7/README.md
+++ b/examples/streamlit/yolov7/README.md
@@ -23,7 +23,7 @@ $ pip install -r requirements.txt
 #   --pipeline-backend-base-url=< pipeline backend base URL >
 #   --yolov4=< YOLOv4 pipeline ID >
 #   --yolov7=< YOLOv7 pipeline ID >
-$ streamlit run main.py -- --demo-url=http://localhost:8501 --pipeline-backend-base-url=http://localhost:8081 --yolov4=yolov4 --yolov7=yolov7
+$ streamlit run main.py -- --demo-url=http://localhost:8501 --pipeline-backend-base-url=http://localhost:8080 --yolov4=yolov4 --yolov7=yolov7
 ```
 Now go to `http://localhost:8501/` 🎉
 
@@ -34,7 +34,7 @@ $ docker build -t streamlit-yolov7 .
 ```
 Run the Docker container and connect to VDP 
 ```bash
-$ docker run -p 8501:8501 --network instill-network streamlit-yolov7 -- --demo-url=http://localhost:8501 --pipeline-backend-base-url=http://pipeline-backend:8081 --yolov4=yolov4 --yolov7=yolov7
+$ docker run -p 8501:8501 --network instill-network streamlit-yolov7 -- --demo-url=http://localhost:8501 --pipeline-backend-base-url=http://api-gateway:8080 --yolov4=yolov4 --yolov7=yolov7
 
 You can now view your Streamlit app in your browser.
 

--- a/examples/streamlit/yolov7/main.py
+++ b/examples/streamlit/yolov7/main.py
@@ -58,9 +58,11 @@ def trigger_detection_pipeline(pipeline_backend_base_url: str, pipeline_id: str,
 
     """
     body = {
-        "inputs": [
+        "task_inputs": [
             {
-                'image_url': image_url
+                "detection": {
+                    'image_url': image_url
+                }
             }
         ]
     }
@@ -132,9 +134,11 @@ def display_trigger_request_code():
         curl -X POST '{pipeline_backend_base_url}/pipelines/<pipeline-id>/trigger' \\
         --header 'Content-Type: application/json' \\
         --data-raw '{{
-            "inputs": [
+            "task_inputs": [
                 {{
-                    "image_url": "{image_url}"
+                    "detection": {{
+                        "image_url": "{image_url}"
+                    }}
                 }}
             ]
         }}'

--- a/examples/streamlit/yolov7/main.py
+++ b/examples/streamlit/yolov7/main.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
     parser.add_argument('--demo-url', type=str,
                         default='https://demo.instill.tech/yolov4-vs-yolov7', help='demo URL')
     parser.add_argument('--pipeline-backend-base-url', type=str,
-                        default='http://localhost:8081', help='pipeline backend base URL')
+                        default='http://localhost:8080', help='pipeline backend base URL')
     parser.add_argument('--yolov4', type=str,
                         default='yolov4', help='YOLOv4 pipeline ID on VDP')
     parser.add_argument('--yolov7', type=str,


### PR DESCRIPTION
Because

- we want to deploy the demo online

This commit

- add Dockerfile for stomata example
- push the example docker image to DockerHub
- update the pipeline backend base URL to use the API gateway entry point for all examples
