### PR TITLE
chore: remove standalone m1 conda image dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 include .env
 export
 
-TRITON_CONDA_ENV_PLATFORM := $(if $(filter arm64,$(shell uname -m)),m1,cpu)
+TRITON_CONDA_ENV_PLATFORM := cpu
 ifeq ($(shell nvidia-smi 2>/dev/null 1>&2; echo $$?),0)
 	TRITONSERVER_RUNTIME := nvidia
 	TRITON_CONDA_ENV_PLATFORM := gpu


### PR DESCRIPTION
Because

- cpu version of triton-conda-env image works on apple silicon machines, there is no need for standalone m1 image

This commit

- remove logic clause for apple silicon machines in Makefile
