### PR TITLE
fix: fix console e2e config

### DIFF
--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -52,7 +52,7 @@ jobs:
           cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright .
           docker run -t --rm \
             -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://console:3000 \
-            -e NEXT_PUBLIC_API_GATEWAY_BASE_URL=http://api-gateway:8080 \
+            -e NEXT_PUBLIC_API_GATEWAY_BASE_URL_FOR_CLIENT=http://api-gateway:8080 \
             -e NEXT_PUBLIC_API_VERSION=v1alpha \
             -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
             -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \


### PR DESCRIPTION
Because

- console e2e config is wrong when set up the workflow

This commit

- fix console e2e config
