### PR TITLE
ci: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report any issues with the platform
+title: ""
+labels: bug
+assignees: ""
+---
+
+Found a bug? Please fill out the sections 🙌
+
+### Describe the Bug
+
+A clear and concise description of what the bug is.
+
+### Steps to Reproduce
+
+1. Go to '...'
+2. Click on '....'
+3. ... 
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Technical details
+- Service name: [e.g. `pipeline-backend`]
+- Service version: [e.g., 0.9.4-alpha]
+- VDP version [e.g. 0.6.0-alpha]
+- OS: [e.g. Linux]
+- Browser [e.g. chrome, safari]
+- Anything else that you think could be helpful, such as screen recordings and console logs
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions
+    url: https://discord.gg/sevxWsqpGh
+    about: Join our Discord community to ask a question about the project in the #vdp channel

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a feature or idea
+title: ""
+labels: feature
+assignees: ""
+---
+
+### Is your feature request related to a problem?
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+### Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context**
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Because

- we want to provide a series of issue templates to standardise vdp issues

This commit

- add issue templates
