### PR TITLE
chore(temporal): remove model instance search attribute in Temporal

### DIFF
--- a/charts/vdp/templates/model/deployment.yaml
+++ b/charts/vdp/templates/model/deployment.yaml
@@ -66,7 +66,7 @@ spec:
           args:
             - >
               until tctl cluster health 2>&1 > /dev/null; do echo waiting for Temporal; sleep 2; done &&
-              tctl --auto_confirm admin cluster add-search-attributes --name Type --type Text --name ModelUID --type Text --name ModelInstanceUID --type Text --name Owner --type Text &&
+              tctl --auto_confirm admin cluster add-search-attributes --name Type --type Text --name ModelUID --type Text --name Owner --type Text &&
               sleep 10
           env:
             - name: TEMPORAL_CLI_ADDRESS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -434,7 +434,7 @@ services:
     restart: unless-stopped
     environment:
       TEMPORAL_CLI_ADDRESS: ${TEMPORAL_HOST}:${TEMPORAL_PORT}
-    entrypoint: /bin/bash -c "tctl --auto_confirm admin cluster add-search-attributes --name Type --type Text --name ModelUID --type Text --name ModelInstanceUID --type Text --name Owner --type Text --name ConnectorUID --type Text && tail -f /dev/null"
+    entrypoint: /bin/bash -c "tctl --auto_confirm admin cluster add-search-attributes --name Type --type Text --name ModelUID --type Text --name Owner --type Text --name ConnectorUID --type Text && tail -f /dev/null"
     depends_on:
       temporal:
         condition: service_healthy


### PR DESCRIPTION
Because

- remove model instance concept in the model-backend

This commit

- remove model instance search attribute in Temporal
