### PR TITLE
chore(temporal): remove search attributes

### DIFF
--- a/charts/vdp/templates/temporal/admintools-deployment.yaml
+++ b/charts/vdp/templates/temporal/admintools-deployment.yaml
@@ -69,7 +69,6 @@ spec:
                 SQL_DATABASE=temporal_visibility temporal-sql-tool update -schema-dir schema/postgresql/v96/visibility/versioned
               fi &&
               until tctl cluster health 2>&1 > /dev/null; do echo waiting for Temporal; sleep 2; done &&
-              tctl --auto_confirm admin cluster add-search-attributes --name Type --type Text --name Owner --type Text --name ConnectorUID --type Text --name ModelUID --type Text &&
               tail -f /dev/null
           ports:
             - name: http

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -434,7 +434,6 @@ services:
     restart: unless-stopped
     environment:
       TEMPORAL_CLI_ADDRESS: ${TEMPORAL_HOST}:${TEMPORAL_PORT}
-    entrypoint: /bin/bash -c "tctl --auto_confirm admin cluster add-search-attributes --name Type --type Text --name ModelUID --type Text --name Owner --type Text --name ConnectorUID --type Text && tail -f /dev/null"
     depends_on:
       temporal:
         condition: service_healthy


### PR DESCRIPTION
Because

- the Temporal cloud does not support search attributes

This commit

- remove search attributes creation in Temporal admin tool