### PR TITLE
chore(docker-compose): fix model_backend_init_model not running for some profiles

### DIFF
--- a/docker-compose.latest.yml
+++ b/docker-compose.latest.yml
@@ -146,6 +146,12 @@ services:
   model_backend_init_model:
     profiles:
       - all
+      - api-gateway
+      - pipeline
+      - connector
+      - mgmt
+      - console
+      - controller
     image: ${MODEL_BACKEND_IMAGE}:latest
     environment:
       CFG_INITMODEL_ENABLED: "false"


### PR DESCRIPTION
Because

- `model_backend_init_model` should run for all profiles except `model` itself.

This commit

- Add more profile for `model_backend_init_model`
