### PR TITLE
chore(helm): add logics to accommodate Temporal Cloud

### DIFF
--- a/charts/vdp/templates/apigateway/configmap.yaml
+++ b/charts/vdp/templates/apigateway/configmap.yaml
@@ -11,8 +11,8 @@ data:
     API_GATEWAY_METRICS_PORT={{ template "vdp.apigateway.metricsPort" . }}
     API_GATEWAY_LOG_LEVEL={{ upper .Values.logLevel }}
     {{- if .Values.internalTLS.enabled }}
-    API_GATEWAY_CERT_FILE=/etc/vdp/ssl/apigateway/tls.cert
-    API_GATEWAY_KEY_FILE=/etc/vdp/ssl/apigateway/tls.key
+    API_GATEWAY_CERT_FILE=/etc/ssl/api-gateway/tls.cert
+    API_GATEWAY_KEY_FILE=/etc/ssl/api-gateway/tls.key
     {{- end }}
 
     # pipeline-backend

--- a/charts/vdp/templates/apigateway/deployment.yaml
+++ b/charts/vdp/templates/apigateway/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - |
               make config && \
               krakend run \
-            {{- if (eq .Values.logLevel "debug") }}
+            {{- if (eq (.Values.logLevel | upper) "DEBUG") }}
               --debug \
             {{- end }}
               --config krakend.json
@@ -90,14 +90,14 @@ spec:
               protocol: TCP
           volumeMounts:
             - name: config
-              mountPath: "/api-gateway/config/.env"
+              mountPath: {{ .Values.apigateway.configPath }}
               subPath: ".env"
             {{- if .Values.internalTLS.enabled }}
             - name: apigateway-internal-certs
               mountPath: "/etc/vdp/ssl/apigateway"
             {{- end }}
             {{- with .Values.apigateway.extraVolumeMounts }}
-            {{- toYaml . | indent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.apigateway.extraEnv }}
           env:
@@ -115,8 +115,8 @@ spec:
           secret:
             secretName: {{ template "vdp.internalTLS.apigateway.secretName" . }}
         {{- end }}
-        {{- if .Values.apigateway.extraVolumes }}
-        {{- toYaml .Values.apigateway.extraVolumes | indent 6 }}
+        {{- with .Values.apigateway.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.apigateway.nodeSelector }}
       nodeSelector:

--- a/charts/vdp/templates/connector/configmap.yaml
+++ b/charts/vdp/templates/connector/configmap.yaml
@@ -12,7 +12,7 @@ data:
       publicport: {{ template "vdp.connector.publicPort" . }}
       edition: {{ .Values.edition }}
       disableusage: {{ .Values.disableUsage }}
-      debug: {{ ternary "true" "false" (eq .Values.logLevel "debug") }}
+      debug: {{ ternary "true" "false" (eq (.Values.logLevel | upper) "DEBUG") }}
       {{- if .Values.internalTLS.enabled }}
       https:
         cert: /etc/vdp/ssl/connector/tls.crt
@@ -42,8 +42,12 @@ data:
         redisoptions:
           addr: {{ default (include "vdp.redis.addr" .) .Values.redis.external.addr }}
     temporal:
-      hostport: {{ template "vdp.temporal" . }}-frontend-headless:{{ template "vdp.temporal.frontend.grpcPort" . }}
-      namespace: connector-backend
+      hostport: {{ default (printf "%s-frontend-headless:%s" (include "vdp.temporal" .) (include "vdp.temporal.frontend.grpcPort" .)) .Values.connector.temporal.hostPort }}
+      namespace: {{ default "connector-backend" .Values.connector.temporal.namespace }}
+      ca: {{ default "" .Values.connector.temporal.ca }}
+      cert: {{ default "" .Values.connector.temporal.cert }}
+      key: {{ default "" .Values.connector.temporal.key }}
+      serverName: {{ default "" .Values.connector.temporal.serverName }}
     pipelinebackend:
       host: {{ template "vdp.pipeline" . }}
       publicport: {{ template "vdp.pipeline.publicPort" . }}

--- a/charts/vdp/templates/connector/deployment.yaml
+++ b/charts/vdp/templates/connector/deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - name: PGUSER
               value: {{ template "vdp.database.username" . }}
         {{- end }}
+        {{- if .Values.temporal.enabled }}
         - name: temporal-admin-tools
           securityContext:
             runAsUser: 0
@@ -69,6 +70,7 @@ spec:
           env:
             - name: TEMPORAL_CLI_ADDRESS
               value: "{{ template "vdp.temporal" . }}-frontend:{{ template "vdp.temporal.frontend.grpcPort" . }}"
+        {{- end }}
         - name: connector-backend-migration
           image: {{ .Values.connector.image.repository }}:{{ .Values.connector.image.tag }}
           imagePullPolicy: {{ .Values.connector.image.pullPolicy }}
@@ -76,10 +78,10 @@ spec:
           resources:
             {{- toYaml .Values.connector.resources | nindent 12 }}
           {{- end }}
-          command: ["./connector-backend-migrate"]
+          command: [./{{ .Values.connector.commandName.migration }}]
           volumeMounts:
             - name: config
-              mountPath: /connector-backend/config/config.yaml
+              mountPath: {{ .Values.connector.configPath }}
               subPath: config.yaml
         - name: connector-backend-init
           image: {{ .Values.connector.image.repository }}:{{ .Values.connector.image.tag }}
@@ -88,10 +90,10 @@ spec:
           resources:
             {{- toYaml .Values.connector.resources | nindent 12 }}
           {{- end }}
-          command: ["./connector-backend-init"]
+          command: [./{{ .Values.connector.commandName.init }}]
           volumeMounts:
             - name: config
-              mountPath: /connector-backend/config/config.yaml
+              mountPath: {{ .Values.connector.configPath }}
               subPath: config.yaml
         - name: wait-for-dependencies
           image: curlimages/curl:8.00.1
@@ -138,18 +140,21 @@ spec:
           resources:
             {{- toYaml .Values.connector.resources | nindent 12 }}
           {{- end }}
-          command: ["./connector-backend-worker"]
+          command: [./{{ .Values.connector.commandName.worker }}]
           env:
             - name: DOCKER_HOST
               value: tcp://localhost:2375
           volumeMounts:
             - name: config
-              mountPath: /connector-backend/config/config.yaml
+              mountPath: {{ .Values.connector.configPath }}
               subPath: config.yaml
             - name: vdp
               mountPath: /vdp
             - name: airbyte
               mountPath: /airbyte
+            {{- with .Values.connector.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         - name: connector-backend
           image: {{ .Values.connector.image.repository }}:{{ .Values.connector.image.tag }}
           imagePullPolicy: {{ .Values.connector.image.pullPolicy }}
@@ -171,21 +176,21 @@ spec:
           resources:
             {{- toYaml .Values.connector.resources | nindent 12 }}
           {{- end }}
-          command: ["./connector-backend"]
+          command: [./{{ .Values.connector.commandName.main }}]
           ports:
             - name: {{ ternary "https" "http" .Values.internalTLS.enabled }}-public
               containerPort: {{ template "vdp.connector.publicPort" . }}
               protocol: TCP
           volumeMounts:
             - name: config
-              mountPath: /connector-backend/config/config.yaml
+              mountPath: {{ .Values.connector.configPath }}
               subPath: config.yaml
             {{- if .Values.internalTLS.enabled }}
             - name: connector-internal-certs
               mountPath: "/etc/vdp/ssl/connector"
             {{- end }}
             {{- with .Values.connector.extraVolumeMounts }}
-            {{- toYaml . | indent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.connector.extraEnv }}
           env:
@@ -209,8 +214,8 @@ spec:
           secret:
             secretName: {{ template "vdp.internalTLS.connector.secretName" . }}
         {{- end }}
-        {{- if .Values.connector.extraVolumes }}
-        {{- toYaml .Values.connector.extraVolumes | indent 6 }}
+        {{- with .Values.connector.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.connector.nodeSelector }}
       nodeSelector:

--- a/charts/vdp/templates/console/deployment.yaml
+++ b/charts/vdp/templates/console/deployment.yaml
@@ -81,7 +81,7 @@ spec:
               mountPath: "/etc/vdp/ssl/console"
             {{- end }}
             {{- with .Values.console.extraVolumeMounts }}
-            {{- toYaml . | indent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
             - name: NEXT_PUBLIC_API_VERSION
@@ -118,8 +118,8 @@ spec:
           secret:
             secretName: {{ template "vdp.internalTLS.console.secretName" . }}
         {{- end }}
-        {{- if .Values.console.extraVolumes }}
-        {{- toYaml .Values.console.extraVolumes | indent 6 }}
+        {{- with .Values.console.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.console.nodeSelector }}
       nodeSelector:

--- a/charts/vdp/templates/controller/configmap.yaml
+++ b/charts/vdp/templates/controller/configmap.yaml
@@ -12,7 +12,7 @@ data:
       edition: {{ .Values.edition }}
       loopinterval: {{ .Values.controller.loopinterval }}
       timeout: 120
-      debug: {{ ternary "true" "false" (eq .Values.logLevel "debug") }}
+      debug: {{ ternary "true" "false" (eq (.Values.logLevel | upper) "DEBUG") }}
       {{- if .Values.internalTLS.enabled }}
       https:
         cert: /etc/vdp/ssl/controller/tls.crt

--- a/charts/vdp/templates/controller/deployment.yaml
+++ b/charts/vdp/templates/controller/deployment.yaml
@@ -98,21 +98,21 @@ spec:
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
           {{- end }}
-          command: ["./controller"]
+          command: [./{{ .Values.controller.commandName.main }}]
           ports:
             - name: {{ ternary "https" "http" .Values.internalTLS.enabled }}-private
               containerPort: {{ template "vdp.controller.privatePort" . }}
               protocol: TCP
           volumeMounts:
             - name: config
-              mountPath: /controller/config/config.yaml
+              mountPath: {{ .Values.controller.configPath }}
               subPath: config.yaml
             {{- if .Values.internalTLS.enabled }}
             - name: controller-internal-certs
               mountPath: "/etc/vdp/ssl/controller"
             {{- end }}
             {{- with .Values.controller.extraVolumeMounts }}
-            {{- toYaml . | indent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.controller.extraEnv }}
           env:
@@ -128,8 +128,8 @@ spec:
         - name: controller-internal-certs
           secret:
             secretName: {{ template "vdp.internalTLS.controller.secretName" . }}
-        {{- if .Values.controller.extraVolumes }}
-        {{- toYaml .Values.controller.extraVolumes | indent 6 }}
+        {{- with .Values.controller.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/charts/vdp/templates/mgmt/configmap.yaml
+++ b/charts/vdp/templates/mgmt/configmap.yaml
@@ -12,7 +12,7 @@ data:
       publicport: {{ template "vdp.mgmt.publicPort" . }}
       edition: {{ .Values.edition }}
       disableusage: {{ .Values.disableUsage }}
-      debug: {{ ternary "true" "false" (eq .Values.logLevel "debug") }}
+      debug: {{ ternary "true" "false" (eq (.Values.logLevel | upper) "DEBUG") }}
       maxdatasize: {{ .Values.maxDataSizeMB }}
       {{- if .Values.internalTLS.enabled }}
       https:

--- a/charts/vdp/templates/mgmt/deployment.yaml
+++ b/charts/vdp/templates/mgmt/deployment.yaml
@@ -63,10 +63,10 @@ spec:
           resources:
             {{- toYaml .Values.mgmt.resources | nindent 12 }}
           {{- end }}
-          command: ["./mgmt-backend-migrate"]
+          command: [./{{ .Values.mgmt.commandName.migration }}]
           volumeMounts:
             - name: config
-              mountPath: /mgmt-backend/config/config.yaml
+              mountPath: {{ .Values.mgmt.configPath }}
               subPath: config.yaml
         - name: mgmt-backend-init
           image: {{ .Values.mgmt.image.repository }}:{{ .Values.mgmt.image.tag }}
@@ -75,10 +75,10 @@ spec:
           resources:
             {{- toYaml .Values.mgmt.resources | nindent 12 }}
           {{- end }}
-          command: ["./mgmt-backend-init"]
+          command: [./{{ .Values.mgmt.commandName.init }}]
           volumeMounts:
             - name: config
-              mountPath: /mgmt-backend/config/config.yaml
+              mountPath: {{ .Values.mgmt.configPath }}
               subPath: config.yaml
         {{- with .Values.mgmt.extraInitContainers }}
         {{- toYaml . | indent 8 }}
@@ -105,7 +105,7 @@ spec:
           resources:
             {{- toYaml .Values.mgmt.resources | nindent 12 }}
           {{- end }}
-          command: ["./mgmt-backend"]
+          command: [./{{ .Values.mgmt.commandName.main }}]
           ports:
             - name: {{ ternary "https" "http" .Values.internalTLS.enabled }}-admin
               containerPort: {{ template "vdp.mgmt.privatePort" . }}
@@ -115,14 +115,14 @@ spec:
               protocol: TCP
           volumeMounts:
             - name: config
-              mountPath: /mgmt-backend/config/config.yaml
+              mountPath: {{ .Values.mgmt.configPath }}
               subPath: config.yaml
             {{- if .Values.internalTLS.enabled }}
             - name: mgmt-internal-certs
               mountPath: "/etc/vdp/ssl/mgmt"
             {{- end }}
             {{- with .Values.mgmt.extraVolumeMounts }}
-            {{- toYaml . | indent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.mgmt.extraEnv }}
           env:
@@ -140,8 +140,8 @@ spec:
           secret:
             secretName: {{ template "vdp.internalTLS.mgmt.secretName" . }}
         {{- end }}
-        {{- if .Values.mgmt.extraVolumes }}
-        {{- toYaml .Values.mgmt.extraVolumes | indent 6 }}
+        {{- with .Values.mgmt.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.mgmt.nodeSelector }}
       nodeSelector:

--- a/charts/vdp/templates/model/configmap.yaml
+++ b/charts/vdp/templates/model/configmap.yaml
@@ -12,7 +12,7 @@ data:
       publicport: {{ template "vdp.model.publicPort" . }}
       edition: {{ .Values.edition }}
       disableusage: {{ .Values.disableUsage }}
-      debug: {{ ternary "true" "false" (eq .Values.logLevel "debug") }}
+      debug: {{ ternary "true" "false" (eq (.Values.logLevel | upper) "DEBUG") }}
       itmode: {{ .Values.enableITMode }}
       maxdatasize: {{ .Values.maxDataSizeMB }}
       {{- if .Values.internalTLS.enabled }}
@@ -75,8 +75,12 @@ data:
       semanticsegmentation: 8
       textgeneration: 1
     temporal:
-      hostport: {{ template "vdp.temporal" . }}-frontend-headless:{{ template "vdp.temporal.frontend.grpcPort" . }}
-      namespace: model-backend
+      hostport: {{ default (printf "%s-frontend-headless:%s" (include "vdp.temporal" .) (include "vdp.temporal.frontend.grpcPort" .)) .Values.model.temporal.hostPort }}
+      namespace: {{ default "model-backend" .Values.model.temporal.namespace }}
+      ca: {{ default "" .Values.model.temporal.ca }}
+      cert: {{ default "" .Values.model.temporal.cert }}
+      key: {{ default "" .Values.model.temporal.key }}
+      serverName: {{ default "" .Values.model.temporal.serverName }}
     initmodel:
       path: {{ .Values.model.initModel.path }}
       enabled: {{ .Values.model.initModel.enabled }}

--- a/charts/vdp/templates/model/deployment.yaml
+++ b/charts/vdp/templates/model/deployment.yaml
@@ -57,6 +57,7 @@ spec:
             - name: PGUSER
               value: {{ template "vdp.database.username" . }}
         {{- end }}
+        {{- if .Values.temporal.enabled }}
         - name: temporal-admin-tools
           securityContext:
             runAsUser: 0
@@ -69,6 +70,7 @@ spec:
           env:
             - name: TEMPORAL_CLI_ADDRESS
               value: "{{ template "vdp.temporal" . }}-frontend:{{ template "vdp.temporal.frontend.grpcPort" . }}"
+        {{- end }}
         - name: model-backend-migration
           image: {{ .Values.model.image.repository }}:{{ .Values.model.image.tag }}
           imagePullPolicy: {{ .Values.model.image.pullPolicy }}
@@ -76,10 +78,10 @@ spec:
           resources:
             {{- toYaml .Values.model.resources | nindent 12 }}
           {{- end }}
-          command: ["./model-backend-migrate"]
+          command: [./{{ .Values.model.commandName.migration }}]
           volumeMounts:
             - name: config
-              mountPath: /model-backend/config/config.yaml
+              mountPath: {{ .Values.model.configPath }}
               subPath: config.yaml
         - name: model-backend-init
           image: {{ .Values.model.image.repository }}:{{ .Values.model.image.tag }}
@@ -88,10 +90,10 @@ spec:
           resources:
             {{- toYaml .Values.model.resources | nindent 12 }}
           {{- end }}
-          command: ["./model-backend-init"]
+          command: [./{{ .Values.model.commandName.init }}]
           volumeMounts:
             - name: config
-              mountPath: /model-backend/config/config.yaml
+              mountPath: {{ .Values.model.configPath }}
               subPath: config.yaml
         - name: wait-for-dependencies
           image: curlimages/curl:8.00.1
@@ -116,13 +118,16 @@ spec:
           resources:
             {{- toYaml .Values.model.resources | nindent 12 }}
           {{- end }}
-          command: ["./model-backend-worker"]
+          command: [./{{ .Values.model.commandName.worker }}]
           volumeMounts:
             - name: config
-              mountPath: /model-backend/config/config.yaml
+              mountPath: {{ .Values.model.configPath }}
               subPath: config.yaml
             - name: model-repository
               mountPath: /model-repository
+            {{- with .Values.model.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         - name: model-backend
           image: {{ .Values.model.image.repository }}:{{ .Values.model.image.tag }}
           imagePullPolicy: {{ .Values.model.image.pullPolicy }}
@@ -146,14 +151,14 @@ spec:
           resources:
             {{- toYaml .Values.model.resources | nindent 12 }}
           {{- end }}
-          command: ["./model-backend"]
+          command: [./{{ .Values.model.commandName.main }}]
           ports:
             - name: {{ ternary "https" "http" .Values.internalTLS.enabled }}-public
               containerPort: {{ template "vdp.model.publicPort" . }}
               protocol: TCP
           volumeMounts:
             - name: config
-              mountPath: /model-backend/config/config.yaml
+              mountPath: {{ .Values.model.configPath }}
               subPath: config.yaml
             - name: model-repository
               mountPath: /model-repository
@@ -162,7 +167,7 @@ spec:
               mountPath: "/etc/vdp/ssl/model"
             {{- end }}
             {{- with .Values.model.extraVolumeMounts }}
-            {{- toYaml . | indent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.model.extraEnv }}
           env:
@@ -190,8 +195,8 @@ spec:
           secret:
             secretName: {{ template "vdp.internalTLS.model.secretName" . }}
         {{- end }}
-        {{- if .Values.model.extraVolumes }}
-        {{- toYaml .Values.model.extraVolumes | indent 6 }}
+        {{- with .Values.model.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.model.nodeSelector }}
       nodeSelector:

--- a/charts/vdp/templates/model/post-install-job.yaml
+++ b/charts/vdp/templates/model/post-install-job.yaml
@@ -42,7 +42,7 @@ spec:
       - name: model-backend-init-model
         image: {{ .Values.model.image.repository }}:{{ .Values.model.image.tag }}
         imagePullPolicy: {{ .Values.model.image.pullPolicy }}
-        command: ["./model-backend-init-model"]
+          command: [./{{ .Values.model.commandName.initModel }}]
         volumeMounts:
           - name: config
             mountPath: /model-backend/config/config.yaml

--- a/charts/vdp/templates/pipeline/configmap.yaml
+++ b/charts/vdp/templates/pipeline/configmap.yaml
@@ -12,7 +12,7 @@ data:
       publicport: {{ template "vdp.pipeline.publicPort" . }}
       edition: {{ .Values.edition }}
       disableusage: {{ .Values.disableUsage }}
-      debug: {{ ternary "true" "false" (eq .Values.logLevel "debug") }}
+      debug: {{ ternary "true" "false" (eq (.Values.logLevel | upper) "DEBUG") }}
       maxdatasize: {{ .Values.maxDataSizeMB }}
       {{- if .Values.internalTLS.enabled }}
       https:

--- a/charts/vdp/templates/pipeline/deployment.yaml
+++ b/charts/vdp/templates/pipeline/deployment.yaml
@@ -63,10 +63,10 @@ spec:
           resources:
             {{- toYaml .Values.pipeline.resources | nindent 12 }}
           {{- end }}
-          command: ["./pipeline-backend-migrate"]
+          command: [./{{ .Values.pipeline.commandName.migration }}]
           volumeMounts:
             - name: config
-              mountPath: /pipeline-backend/config/config.yaml
+              mountPath: {{ .Values.pipeline.configPath }}
               subPath: config.yaml
         - name: wait-for-dependencies
           image: curlimages/curl:8.00.1
@@ -114,21 +114,21 @@ spec:
           resources:
             {{- toYaml .Values.pipeline.resources | nindent 12 }}
           {{- end }}
-          command: ["./pipeline-backend"]
+          command: [./{{ .Values.pipeline.commandName.main }}]
           ports:
             - name: {{ ternary "https" "http" .Values.internalTLS.enabled }}-public
               containerPort: {{ template "vdp.pipeline.publicPort" . }}
               protocol: TCP
           volumeMounts:
             - name: config
-              mountPath: /pipeline-backend/config/config.yaml
+              mountPath: {{ .Values.pipeline.configPath }}
               subPath: config.yaml
             {{- if .Values.internalTLS.enabled }}
             - name: pipeline-internal-certs
               mountPath: "/etc/vdp/ssl/pipeline"
             {{- end }}
             {{- with .Values.pipeline.extraVolumeMounts }}
-            {{- toYaml . | indent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.pipeline.extraEnv }}
           env:
@@ -146,8 +146,8 @@ spec:
           secret:
             secretName: {{ template "vdp.internalTLS.pipeline.secretName" . }}
         {{- end }}
-        {{- if .Values.pipeline.extraVolumes }}
-        {{- toYaml .Values.pipeline.extraVolumes | indent 6 }}
+        {{- with .Values.pipeline.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.pipeline.nodeSelector }}
       nodeSelector:

--- a/charts/vdp/templates/temporal/server-deployment.yaml
+++ b/charts/vdp/templates/temporal/server-deployment.yaml
@@ -127,7 +127,7 @@ spec:
             - name: dynamic-config
               mountPath: /etc/temporal/dynamic_config
             {{- with $.Values.temporal.server.extraVolumeMounts }}
-            {{- toYaml . | indent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
             - name: POD_IP

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -224,7 +224,7 @@ persistence:
       existingClaim: ""
       storageClass: ""
       subPath: ""
-      accessMode: ReadWriteOnce
+      accessMode: ReadWriteMany
       size: 10Gi
       annotations: {}
     condaPack:
@@ -256,6 +256,8 @@ apigateway:
     repository: instill/api-gateway
     tag: 0.2.6-alpha
     pullPolicy: Always
+  # -- The path of configuration file for api-gateway
+  configPath: /api-gateway/config/.env
   # -- Set the service account to be used, default if left empty
   serviceAccountName: ""
   # -- Mount the service account token
@@ -307,6 +309,12 @@ pipeline:
     repository: instill/pipeline-backend
     tag: 0.11.2-alpha
     pullPolicy: Always
+  # -- The command names to be executed
+  commandName:
+    migration: pipeline-backend-migrate
+    main: pipeline-backend
+  # -- The path of configuration file for pipeline-backend
+  configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
   dbVersion: 1
   # -- Set the service account to be used, default if left empty
@@ -360,8 +368,24 @@ connector:
     repository: instill/connector-backend
     tag: 0.9.2-alpha
     pullPolicy: Always
+  # -- The command names to be executed
+  commandName:
+    migration: connector-backend-migrate
+    init: connector-backend-init
+    worker: connector-backend-worker
+    main: connector-backend
+  # -- The path of configuration file for connector-backend
+  configPath: /connector-backend/config/config.yaml
   # -- The database migration version
   dbVersion: 1
+  # -- The configuration of Temporal Cloud
+  temporal:
+    hostPort:
+    namespace:
+    ca:
+    cert:
+    key:
+    serverName:
   # -- Set the service account to be used, default if left empty
   serviceAccountName: ""
   # -- Mount the service account token
@@ -413,8 +437,25 @@ model:
     repository: instill/model-backend
     tag: 0.16.2-alpha
     pullPolicy: Always
+  # -- The command names to be executed
+  commandName:
+    migration: model-backend-migrate
+    init: model-backend-init
+    worker: model-backend-worker
+    main: model-backend
+    initModel: model-backend-init-model
+  # -- The path of configuration file for model-backend
+  configPath: /model-backend/config/config.yaml
   # -- The database migration version
   dbVersion: 1
+  # -- The configuration of Temporal Cloud
+  temporal:
+    hostPort:
+    namespace:
+    ca:
+    cert:
+    key:
+    serverName:
   # -- Set the service account to be used, default if left empty
   serviceAccountName: ""
   # -- Mount the service account token
@@ -470,6 +511,13 @@ mgmt:
     repository: instill/mgmt-backend
     tag: 0.3.5-alpha
     pullPolicy: Always
+  # -- The command names to be executed
+  commandName:
+    migration: mgmt-backend-migrate
+    init: mgmt-backend-init
+    main: mgmt-backend
+  # -- The path of configuration file for mgmt-backend
+  configPath: /mgmt-backend/config/config.yaml
   # -- The database migration version
   dbVersion: 1
   # -- Set the service account to be used, default if left empty
@@ -524,6 +572,11 @@ controller:
     repository: instill/controller
     tag: 0.1.2-alpha
     pullPolicy: Always
+  # -- The command names to be executed
+  commandName:
+    main: controller
+  # -- The path of configuration file for mgmt-backend
+  configPath: /controller/config/config.yaml
   # -- Set the service account to be used, default if left empty
   serviceAccountName: ""
   # -- Mount the service account token
@@ -772,8 +825,7 @@ redis:
     # -- Address for redis: <host_redis>:<port_redis>
     addr:
 temporal:
-  # -- If external Temporal is used, set "enabled" to false
-  # and fill the connection informations in "external" section
+  # -- Enable Temporal deployment or not
   enabled: true
   server:
     # -- Enable Temporal server
@@ -1062,8 +1114,6 @@ temporal:
       routing:
         default_to_namespace: default
         issue_report_link: https://github.com/temporalio/web/issues/new/choose # set this field if you need to direct people to internal support forums
-  ## -- The configuration of external Temporal
-  external:
 elasticsearch:
   # -- If external Elasticsearch is used, set "enabled" to false
   # and fill the connection informations in "external" section


### PR DESCRIPTION
Because

- Temporal Cloud requires TLS auth and specific namespace

This commit

- accommodate Helm chart to the required setup
