### PR TITLE
chore(makefile): fix linux integration test host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,10 +270,10 @@ ifeq ($(UNAME_S),Linux)
 		export CONSOLE_CONTAINER_PORT=$$(kubectl get pod --namespace vdp $$CONSOLE_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}") && \
 		kubectl --namespace vdp port-forward $$CONSOLE_POD_NAME 3000:$${CONSOLE_CONTAINER_PORT} > /dev/null 2>&1 &
 	@docker run -it --rm --network host --name backend-helm-integration-test-latest instill/vdp-compose:latest /bin/bash -c " \
-		cd pipeline-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=8080 && cd ~- && \
-		cd connector-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=8080 && cd ~- && \
-		cd model-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=8080 && cd ~- && \
-		cd mgmt-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=8080 && cd ~- \
+		cd pipeline-backend && make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080 && cd ~- && \
+		cd connector-backend && make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080 && cd ~- && \
+		cd model-backend && make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080 && cd ~- && \
+		cd mgmt-backend && make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080 && cd ~- \
 		"
 	@docker run -it --rm \
 		-e NEXT_PUBLIC_CONSOLE_BASE_URL=http://console:3000 \
@@ -366,10 +366,10 @@ ifeq ($(UNAME_S),Linux)
 		export CONSOLE_CONTAINER_PORT=$$(kubectl get pod --namespace vdp $$CONSOLE_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}") && \
 		kubectl --namespace vdp port-forward $$CONSOLE_POD_NAME 3000:$${CONSOLE_CONTAINER_PORT} > /dev/null 2>&1 &
 	@docker run -it --rm --network host --name backend-helm-integration-test-release instill/vdp-compose:release /bin/bash -c " \
-		cd pipeline-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=8080 && cd ~- && \
-		cd connector-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=8080 && cd ~- && \
-		cd model-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=8080 && cd ~- && \
-		cd mgmt-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=8080 && cd ~- \
+		cd pipeline-backend && make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080 && cd ~- && \
+		cd connector-backend && make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080 && cd ~- && \
+		cd model-backend && make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080 && cd ~- && \
+		cd mgmt-backend && make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080 && cd ~- \
 		"
 	@docker run -it --rm \
 		-e NEXT_PUBLIC_CONSOLE_BASE_URL=http://console:3000 \

--- a/Makefile
+++ b/Makefile
@@ -262,8 +262,7 @@ ifeq ($(UNAME_S),Linux)
 		--set console.image.tag=latest \
 		--set triton.nvidiaVisibleDevices=${TRITON_NVIDIA_VISIBLE_DEVICES} \
 		--set apigatewayURL=http://localhost:8080 \
-		--set consoleURL=http://localhost:3000 \
-		--set console.serverApiGatewayBaseUrl=http://localhost:8080
+		--set consoleURL=http://localhost:3000
 	@sleep 1
 	@export CONTROLLER_POD_NAME=$$(kubectl get pods --namespace vdp -l "app.kubernetes.io/component=controller,app.kubernetes.io/instance=vdp" -o jsonpath="{.items[0].metadata.name}") && \
 		kubectl wait --for=condition=Ready pod $$CONTROLLER_POD_NAME -n vdp --timeout=300s || true
@@ -360,8 +359,7 @@ ifeq ($(UNAME_S),Linux)
 		--set console.image.tag=${CONSOLE_VERSION} \
 		--set triton.nvidiaVisibleDevices=${TRITON_NVIDIA_VISIBLE_DEVICES} \
 		--set apigatewayURL=http://localhost:8080 \
-		--set consoleURL=http://localhost:3000 \
-		--set console.serverApiGatewayBaseUrl=http://localhost:8080
+		--set consoleURL=http://localhost:3000
 	@sleep 1
 	@export CONTROLLER_POD_NAME=$$(kubectl get pods --namespace vdp -l "app.kubernetes.io/component=controller,app.kubernetes.io/instance=vdp" -o jsonpath="{.items[0].metadata.name}") && \
 		kubectl wait --for=condition=Ready pod $$CONTROLLER_POD_NAME -n vdp --timeout=300s || true

--- a/charts/vdp/templates/triton/deployment.yaml
+++ b/charts/vdp/templates/triton/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: triton-conda-env
           securityContext:
             runAsUser: 0
-          image: {{ .Values.triton.condaEnv.image.repository }}:{{ .Values.triton.condaEnv.image.tag }}-{{ ternary "cpu" "gpu" (kindIs "invalid" .Values.triton.nvidiaVisibleDevices) }}
+          image: {{ .Values.triton.condaEnv.image.repository }}:{{ .Values.triton.condaEnv.image.tag }}-{{ ternary "cpu" "gpu" (or (eq .Values.triton.nvidiaVisibleDevices "") (kindIs "invalid" .Values.triton.nvidiaVisibleDevices)) }}
           imagePullPolicy: {{ .Values.triton.condaEnv.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args:

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -779,10 +779,10 @@ database:
   affinity: {}
   # -- The maximum number of connections in the idle connection pool per pod.
   # If it <=0, no idle connections are retained.
-  maxIdleConns: 100
+  maxIdleConns: 5
   # -- The maximum number of open connections to the database per pod.
   # If it <= 0, then there is no limit on the number of open connections.
-  maxOpenConns: 1024
+  maxOpenConns: 10
   # -- The maximum amount of time in minutes a connection may be reused.
   # Expired connections may be closed lazily before reuse.
   # If it <= 0, connections are not closed due to a connection's age.


### PR DESCRIPTION
Because

- The integration test host for linux system in Makefile is wrong
- Currently, the posgreSQL set max_connection: 100. But here we set each backend's connection pool size to `1024`. `1024` connection * 4 backend is far exceed `100`. We should make it smaller.
- The `triton.nvidiaVisibleDevices = all` config will stop the triton server running on cpu-only machine
- The console e2e test won't work on linux machine

This commit

- Fix integration test host for linux system in Makefile 
- Update connection pool size
- Pass `nvidiaVisibleDevices` from env.
- Fix console e2e test by removing `serverApiGatewayBaseUrl` from makefile helm install
