### PR TITLE
chore(examples): update trigger endpoints

### DIFF
--- a/examples/instill/streamlit-instance-segmentation-sync-http-http-stomata/main.py
+++ b/examples/instill/streamlit-instance-segmentation-sync-http-http-stomata/main.py
@@ -62,7 +62,7 @@ def trigger_pipeline(api_gateway_url: str, pipeline_id: str, file: BytesIO, file
         pipeline trigger result
 
     """
-    return requests.post("{}/pipelines/{}/trigger-multipart".format(api_gateway_url, pipeline_id),
+    return requests.post("{}/pipelines/{}/triggerSyncMultipart".format(api_gateway_url, pipeline_id),
                          files=[("file", (filename, file))])
 
 
@@ -93,7 +93,7 @@ def display_intro_markdown(pipeline_id="stomata"):
 
     We use open-source [VDP](https://github.com/instill-ai/vdp) to import an [Instance Segmentation model](https://github.com/instill-ai/model-stomata-instance-segmentation-dvc) fine-tuned on the Stomata dataset collected by [the Agricultural Biotechnology Research Center (ABRC) of Academia Sinica](https://abrc.sinica.edu.tw/faculty/?id=yalin).
 
-    VDP instantly gives us the endpoint to perform inference: `https://demo.instill.tech/v1alpha/pipelines/{}/trigger:multipart`
+    VDP instantly gives us the endpoint to perform inference: `https://demo.instill.tech/v1alpha/pipelines/{}/triggerSyncMultipart`
 
 
     """.format(pipeline_id)
@@ -123,7 +123,7 @@ def display_trigger_request_code(pipeline_id, filename):
     r""" Display Trigger request code block
     """
     request_code = f"""
-        curl -X POST '{api_gateway_url}/pipelines/{pipeline_id}/trigger:multipart' \\
+        curl -X POST '{api_gateway_url}/pipelines/{pipeline_id}/triggerSyncMultipart' \\
         --form 'file=@"{filename}"'
         """
     with st.expander(f"cURL"):
@@ -173,7 +173,7 @@ if __name__ == "__main__":
 
         if resp.status_code == 200:
             # Show trigger pipeline response
-            with st.expander(f"POST /pipelines/{pipeline_id}/trigger:multipart response"):
+            with st.expander(f"POST /pipelines/{pipeline_id}/triggerSyncMultipart response"):
                 st.json(resp.json())
 
             boxes_ltwh, rles_str, categories, scores = parse_instance_segmentation_response(

--- a/examples/metabase-object-detection-async-http-postgres/main.py
+++ b/examples/metabase-object-detection-async-http-postgres/main.py
@@ -221,7 +221,7 @@ if __name__ ==  '__main__':
 
     print("\n=====Trigger {} pipeline to process images in '{}'\n".format(opt.pipeline_id, image_dir))
     for files in tqdm(img_batch):
-        resp = requests.post(f'{opt.api_gateway_url}/v1alpha/pipelines/{opt.pipeline_id}/trigger-multipart',
+        resp = requests.post(f'{opt.api_gateway_url}/v1alpha/pipelines/{opt.pipeline_id}/triggerAsyncMultipart',
                         files=[("file", (filename, open(join(image_dir, filename), 'rb'))) for filename in files])
         if resp.status_code == 200:
             data_mapping_indices += resp.json()['data_mapping_indices']

--- a/examples/streamlit-instance-segmentation-sync-http-http/main.py
+++ b/examples/streamlit-instance-segmentation-sync-http-http/main.py
@@ -68,7 +68,7 @@ def trigger_pipeline(api_gateway_url: str, pipeline_id: str, image_url: str) -> 
         ]
     }
 
-    return requests.post("{}/pipelines/{}/trigger".format(api_gateway_url, pipeline_id), json=body)
+    return requests.post("{}/pipelines/{}/triggerSync".format(api_gateway_url, pipeline_id), json=body)
 
 def display_intro_markdown(pipeline_id="inst"):
     r""" Display Markdown about demo introduction
@@ -97,7 +97,7 @@ def display_intro_markdown(pipeline_id="inst"):
 
     We use open-source [VDP](https://github.com/instill-ai/vdp) to import the [Mask R-CNN](https://github.com/instill-ai/model-instance-segmentation-dvc) model pre-trained on COCO dataset.
 
-    VDP instantly gives us the endpoint to perform inference: `https://demo.instill.tech/v1alpha/pipelines/{}/trigger`
+    VDP instantly gives us the endpoint to perform inference: `https://demo.instill.tech/v1alpha/pipelines/{}/triggerSync`
 
 
     """.format(pipeline_id)
@@ -126,7 +126,7 @@ def display_trigger_request_code(pipeline_id):
     r""" Display Trigger request code block
     """
     request_code = f"""
-        curl -X POST '{api_gateway_url}/pipelines/{pipeline_id}/trigger' \\
+        curl -X POST '{api_gateway_url}/pipelines/{pipeline_id}/triggerSync' \\
         --header 'Content-Type: application/json' \\
         --data-raw '{{
             "task_inputs": [
@@ -199,7 +199,7 @@ if __name__ == "__main__":
 
             display_trigger_request_code(pipeline_id)
             # Show trigger pipeline response
-            with st.expander(f"POST /pipelines/{pipeline_id}/trigger response"):
+            with st.expander(f"POST /pipelines/{pipeline_id}/triggerSync response"):
                     st.json(resp.json())
 
         else:

--- a/examples/streamlit-object-detection-sync-http-http/main.py
+++ b/examples/streamlit-object-detection-sync-http-http/main.py
@@ -67,7 +67,7 @@ def trigger_detection_pipeline(api_gateway_url: str, pipeline_id: str, image_url
         ]
     }
 
-    return requests.post("{}/pipelines/{}/trigger".format(api_gateway_url, pipeline_id), json=body)
+    return requests.post("{}/pipelines/{}/triggerSync".format(api_gateway_url, pipeline_id), json=body)
 
 
 def display_intro_markdown(demo_url="https://demo.instill.tech/yolov4-vs-yolov7"):
@@ -99,8 +99,8 @@ def display_intro_markdown(demo_url="https://demo.instill.tech/yolov4-vs-yolov7"
     # Demo
 
     To spice things up, we use open-source [VDP](https://github.com/instill-ai/vdp) to import the official [YOLOv4](https://github.com/AlexeyAB/darknet) and [YOLOv7](https://github.com/WongKinYiu/yolov7) models pre-trained with only [MS-COCO](https://cocodataset.org) dataset. VDP instantly gives us the endpoints to perform inference:
-    1. https://demo.instill.tech/v1alpha/pipelines/yolov4/trigger
-    2. https://demo.instill.tech/v1alpha/pipelines/yolov7/trigger
+    1. https://demo.instill.tech/v1alpha/pipelines/yolov4/triggerSync
+    2. https://demo.instill.tech/v1alpha/pipelines/yolov7/triggerSync
 
     Let's trigger two pipelines with an input image each:
 
@@ -131,7 +131,7 @@ def display_trigger_request_code():
     r""" Display Trigger request code block
     """
     request_code = f"""
-        curl -X POST '{api_gateway_url}/pipelines/<pipeline-id>/trigger' \\
+        curl -X POST '{api_gateway_url}/pipelines/<pipeline-id>/triggerSync' \\
         --header 'Content-Type: application/json' \\
         --data-raw '{{
             "task_inputs": [
@@ -212,7 +212,7 @@ if __name__ == "__main__":
         cols = st.columns(len(pipeline_ids))
         for col, (resp, _, _, _) in zip(cols, pipeline_results):
             if resp.status_code == 200:
-                with col.expander(f"POST /pipelines/{pipeline_id}/trigger response"):
+                with col.expander(f"POST /pipelines/{pipeline_id}/triggerSync response"):
                     st.json(resp.json())
 
         # Display VDP markdown (full column)

--- a/examples/vdp-101/async/trigger.py
+++ b/examples/vdp-101/async/trigger.py
@@ -1,21 +1,15 @@
 import os
 import sys
-import typing
 import pathlib
 import argparse
 import shutil
 from os import listdir, path
 from os.path import isfile, join
-from typing import Final, Any, List, Dict, Tuple
 
 import ffmpeg
 import requests
-import numpy as np
 from tqdm import tqdm
-from tqdm.contrib import tzip
 from google.cloud import storage
-
-from utils import draw_detection
 
 
 ############################################################################
@@ -102,7 +96,7 @@ def trigger_pipeline_multipart(api_gateway_url: str, pipeline_id: str, img_folde
     body = [("file", (img_name, open(os.path.join(img_folder, img_name), 'rb'))) for img_name in img_names]
 
     return requests.post(
-        f"{api_gateway_url}/pipelines/{pipeline_id}/trigger-multipart", 
+        f"{api_gateway_url}/pipelines/{pipeline_id}/triggerAsyncMultipart",
         files=body)
 
 ############################################################################

--- a/examples/vdp-101/sync/sync-http-base64.py
+++ b/examples/vdp-101/sync/sync-http-base64.py
@@ -32,7 +32,7 @@ def trigger_pipeline_base64(api_gateway_url: str, pipeline_id: str, img_string:s
     }
 
     return requests.post(
-        f"{api_gateway_url}/pipelines/{pipeline_id}/trigger", 
+        f"{api_gateway_url}/pipelines/{pipeline_id}/triggerSync",
         json=body)
 
 if __name__ == "__main__":
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     opt = parser.parse_args()
 
     api_gateway_url = opt.api_gateway_url + "/v1alpha"
-    
+
     img_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), opt.image_file)
 
     # Convert JPG to base64 format
@@ -82,6 +82,6 @@ if __name__ == "__main__":
     fig.add_subplot(1, 2, 2)
     plt.imshow(img_draw)
     plt.axis('off')
-    plt.title("Output image with detection resutls", fontsize=24)
-    
+    plt.title("Output image with detection results", fontsize=24)
+
     plt.show()

--- a/examples/vdp-101/sync/sync-http-multipart.py
+++ b/examples/vdp-101/sync/sync-http-multipart.py
@@ -21,7 +21,7 @@ def trigger_pipeline_multipart(pipeline_backend_base_url: str, pipeline_id: str,
     body = [("file", (img, open(img, 'rb'))) for img in images]
 
     return requests.post(
-        f"{pipeline_backend_base_url}/pipelines/{pipeline_id}/trigger-multipart", 
+        f"{pipeline_backend_base_url}/pipelines/{pipeline_id}/triggerSyncMultipart",
         files=body)
 
 if __name__ == "__main__":
@@ -68,5 +68,5 @@ if __name__ == "__main__":
     fig.add_subplot(1, 2, 2)
     plt.imshow(img_draw)
     plt.axis('off')
-    plt.title("Output image with detection resutls", fontsize=24)
+    plt.title("Output image with detection results", fontsize=24)
     plt.show()

--- a/examples/vdp-101/sync/sync-http-url.py
+++ b/examples/vdp-101/sync/sync-http-url.py
@@ -24,7 +24,7 @@ def trigger_pipeline_url(api_gateway_url: str, pipeline_id: str, image_url: str)
     # Prepare JSON Object
     body = {
         "task_inputs": [
-            {   
+            {
                 "detection": {
                     "image_url": image_url
                 }
@@ -33,7 +33,7 @@ def trigger_pipeline_url(api_gateway_url: str, pipeline_id: str, image_url: str)
     }
 
     return requests.post(
-        f"{api_gateway_url}/pipelines/{pipeline_id}/trigger", 
+        f"{api_gateway_url}/pipelines/{pipeline_id}/triggerSync",
         json=body)
 
 if __name__ == "__main__":
@@ -54,10 +54,10 @@ if __name__ == "__main__":
     # Post HTTP request to the SYNC pipeline
     try:
         resp = trigger_pipeline_url(api_gateway_url, opt.pipeline_id, opt.image_url)
-    
+
     except (ValueError, HTTPError, requests.ConnectionError) as err:
         print("Something wrong with the demo: {}".format(err))
-    
+
     # Parse results from the SYNC pipeline
     boxes_ltwh, categories, scores = parse_detection_response(resp)
 
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         plt.imshow(img_draw)
         plt.axis('off')
         plt.title("Output image with detection results", fontsize=24)
-        
+
         plt.show()
 
     except (ValueError, HTTPError, requests.ConnectionError) as err:


### PR DESCRIPTION
Because

- we've updated the trigger endpoints

This commit

- update SYNC pipeline endpoint to `/triggerSync` and `/triggerSyncMultipart`
- update SYNC pipeline endpoint to `/triggerAsync` and `/triggerAsyncMultipart`
