### PR TITLE
chore(helm,docker-compose): use host docker to pull images when connector-backend-init

### DIFF
--- a/charts/vdp/templates/connector/deployment.yaml
+++ b/charts/vdp/templates/connector/deployment.yaml
@@ -80,6 +80,12 @@ spec:
             - name: config
               mountPath: {{ .Values.connector.configPath }}
               subPath: config.yaml
+            - name: docker-socket-volume
+              mountPath: /var/run/docker.sock
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            privileged: true
         - name: wait-for-dependencies
           image: curlimages/curl:8.00.1
           command: ['sh', '-c']
@@ -166,6 +172,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       volumes:
+        - name: docker-socket-volume
+          hostPath:
+            path: /var/run/docker.sock
+            type: Socket
         - name: config
           configMap:
             name: {{ template "vdp.connector" . }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,7 @@ services:
     image: ${CONNECTOR_BACKEND_IMAGE}:${CONNECTOR_BACKEND_VERSION}
     restart: on-failure
     environment:
+      DOCKER_HOST: tcp://${SOCAT_HOST}:${SOCAT_PORT}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres


### PR DESCRIPTION
Because

- we need to download the Airbyte images when `connector-backend-init`, but we can not use `dind` in pod initContainers. So we need to use host docker to download the images.

This commit

- use host docker to pull images when connector-backend-init
