### PR TITLE
chore(helm): upgrade pipeline-backend db version

### DIFF
--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -240,7 +240,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 2
+  dbVersion: 3
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- the db version for pipeline-backend has been upgraded

This commit

- upgrade pipeline-backend db version in helm charts
