### PR TITLE
chore(helm,compose): add api-gateway project env

### DIFF
--- a/charts/vdp/templates/_helpers.tpl
+++ b/charts/vdp/templates/_helpers.tpl
@@ -136,6 +136,11 @@ app.kubernetes.io/name: {{ include "vdp.name" . }}
   {{- print "base-etcd" -}}
 {{- end -}}
 
+{{/* api-gateway project */}}
+{{- define "vdp.apiGatewayVDP.project" -}}
+  {{- printf "vdp" -}}
+{{- end -}}
+
 {{/* api-gateway service and container port */}}
 {{- define "vdp.apiGatewayVDP.httpPort" -}}
   {{- printf "8080" -}}

--- a/charts/vdp/templates/api-gateway-vdp/configmap.yaml
+++ b/charts/vdp/templates/api-gateway-vdp/configmap.yaml
@@ -7,6 +7,7 @@ data:
     # api-gateway
     API_GATEWAY_HOST={{ template "vdp.apiGatewayVDP" . }}
     API_GATEWAY_PORT={{ template "vdp.apiGatewayVDP.httpPort" . }}
+    API_GATEWAY_PROJECT={{ template "vdp.apiGatewayVDP.project" . }}
     API_GATEWAY_STATS_PORT={{ template "vdp.apiGatewayVDP.statsPort" . }}
     API_GATEWAY_METRICS_PORT={{ template "vdp.apiGatewayVDP.metricsPort" . }}
     API_GATEWAY_LOG_LEVEL={{ upper .Values.logLevel }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     image: ${API_GATEWAY_VDP_IMAGE}:${API_GATEWAY_VDP_VERSION}
     restart: unless-stopped
     environment:
+      API_GATEWAY_PROJECT: vdp
       API_GATEWAY_HOST: ${API_GATEWAY_VDP_HOST}
       API_GATEWAY_PORT: ${API_GATEWAY_VDP_PORT}
       API_GATEWAY_STATS_PORT: ${API_GATEWAY_VDP_STATS_PORT}


### PR DESCRIPTION
Because

- remove setting PROJECT from hostname and rely on env variable instead in `api-gateway`

This commit

- add api-gateway project env
