### PR TITLE
chore(helm): add `prebuiltconnector.enabled` config

### DIFF
--- a/charts/vdp/templates/connector-backend/configmap.yaml
+++ b/charts/vdp/templates/connector-backend/configmap.yaml
@@ -19,6 +19,8 @@ data:
         cert: /etc/instill-ai/vdp/ssl/connector/tls.crt
         key: /etc/instill-ai/vdp/ssl/connector/tls.key
       {{- end }}
+      prebuiltconnector:
+        enabled: {{ .Values.connectorBackend.prebuiltConnectorEnabled }}
     container:
       mountsource:
         vdp: /vdp

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -302,6 +302,8 @@ connectorBackend:
   configPath: /connector-backend/config/config.yaml
   # -- The database migration version
   dbVersion: 3
+  # -- Load the pre-built connector or not
+  prebuiltConnectorEnabled: false
   # -- The configuration of Temporal Cloud
   temporal:
     hostPort:


### PR DESCRIPTION
Because

- we have a config to enable loading pre-built connectors

This commit

- add `prebuiltconnector.enabled` config in helm charts
