### PR TITLE
ci(makefile): remove env BASE_ENABLED

### DIFF
--- a/.env
+++ b/.env
@@ -4,9 +4,6 @@ COMPOSE_PROJECT_NAME=instill-vdp
 # configuration directory path for docker build
 BUILD_CONFIG_DIR_PATH=.
 
-# flag to enable base suite
-BASE_ENABLED=true
-
 # flag to enable usage collection
 USAGE_ENABLED=true
 


### PR DESCRIPTION
Because

- we can direclty detect `instill-base` running in the Makfile target

This commit

- remove ` BASE_ENABLED` 
