### PR TITLE
chore(helm): add extra env to connector_backend_init

### DIFF
--- a/charts/vdp/templates/connector-backend/deployment.yaml
+++ b/charts/vdp/templates/connector-backend/deployment.yaml
@@ -86,6 +86,10 @@ spec:
             runAsUser: 0
             runAsGroup: 0
             privileged: true
+          {{- if .Values.connectorBackend.extraEnv }}
+          env:
+            {{- toYaml .Values.connectorBackend.extraEnv | nindent 12 }}
+          {{- end }}
         - name: wait-for-dependencies
           image: curlimages/curl:8.00.1
           command: ['sh', '-c']


### PR DESCRIPTION
Because

- we need to pass some env variable into connector_backend_init

This commit

- add extra env to connector_backend_init
