### PR TITLE
chore(vdp): add influx cloud config

### DIFF
--- a/charts/vdp/templates/_helpers.tpl
+++ b/charts/vdp/templates/_helpers.tpl
@@ -209,10 +209,6 @@ app.kubernetes.io/name: {{ include "vdp.name" . }}
   {{- printf "8086" -}}
 {{- end -}}
 
-{{- define "base.influxdb.url" -}}
-  {{- printf "http://%s:%s" (include "base.influxdb" .) (include "base.influxdb.port" .) -}}
-{{- end -}}
-
 {{- define "base.jaeger" -}}
   {{- printf "base-jaeger-collector" -}}
 {{- end -}}

--- a/charts/vdp/templates/api-gateway-vdp/deployment.yaml
+++ b/charts/vdp/templates/api-gateway-vdp/deployment.yaml
@@ -51,10 +51,8 @@ spec:
           - >
             while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${PIPELINE_BACKEND_HOST}:${PIPELINE_BACKEND_PORT}/v1alpha/health/pipeline)" != "200" ]]; do echo waiting for pipeline-backend; sleep 1; done &&
             while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${CONNECTOR_BACKEND_HOST}:${CONNECTOR_BACKEND_PORT}/v1alpha/health/connector)" != "200" ]]; do echo waiting for connector-backend; sleep 1; done &&
-            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${CONTROLLER_VDP_HOST}:${CONTROLLER_VDP_PORT}/v1alpha/health/controller)" != "200" ]]; do echo waiting for controller-vdp; sleep 1; done
-          {{- if .Values.tags.observability }}
-            && while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${INFLUXDB_HOST}:${INFLUXDB_PORT}/health)" != "200" ]]; do echo waiting for influxdb; sleep 1; done
-          {{- end }}
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${CONTROLLER_VDP_HOST}:${CONTROLLER_VDP_PORT}/v1alpha/health/controller)" != "200" ]]; do echo waiting for controller-vdp; sleep 1; done &&
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${INFLUXDB_HOST}:${INFLUXDB_PORT}/health)" != "200" ]]; do echo waiting for influxdb; sleep 1; done
           env:
             - name: PIPELINE_BACKEND_HOST
               value: "{{ template "vdp.pipelineBackend" . }}"

--- a/charts/vdp/templates/pipeline-backend/configmap.yaml
+++ b/charts/vdp/templates/pipeline-backend/configmap.yaml
@@ -62,10 +62,10 @@ data:
         maxconnections: {{ .Values.database.maxOpenConns }}
         connlifetime: {{ .Values.database.maxConnLifeTime }}
     influxdb:
-      url: {{ template "base.influxdb.url" . }}
-      token: {{ .Values.influxdb2.adminUser.token }}
-      org: {{ .Values.influxdb2.adminUser.organization }}
-      bucket: {{ .Values.influxdb2.adminUser.bucket }}
+      url: {{ .Values.influxdbCloud.url }}
+      token: {{ .Values.influxdbCloud.token }}
+      org: {{ .Values.influxdbCloud.organization }}
+      bucket: {{ .Values.influxdbCloud.bucket }}
       flushinterval: 10 # In seconds for non-blocking batch mode
       https:
         cert:

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -475,16 +475,11 @@ temporal:
     tolerations: []
     affinity: {}
 
-influxdb2:
-  service:
-    port: 8086
-  adminUser:
-    organization: instill-ai
-    bucket: instill-ai
-    retention_policy: 1w
-    user: admin
-    password: password
-    token: i-love-instill-ai
+influxdbCloud:
+  url: 'https://instill.com'
+  token: "IloveInstill"
+  organization: "instill-ai"
+  bucket: 'Instill'
 
 tags:
   observability: true

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -476,10 +476,10 @@ temporal:
     affinity: {}
 
 influxdbCloud:
-  url: 'https://instill.com'
-  token: "IloveInstill"
+  url: "http://base-influxdb2:8086"
+  token: "i-love-instill-ai"
   organization: "instill-ai"
-  bucket: 'Instill'
+  bucket: "instill-ai"
 
 tags:
   observability: true


### PR DESCRIPTION
Because

- add influxdb cloud section to pass different values than self-hosted influxdb
- separate out observability and prometheus-stack

This commit

- add influx cloud config section in values.yaml
- add prometheusStack tag
