### PR TITLE
chore(helm): increase ingress timeout

### DIFF
--- a/charts/vdp/templates/api-gateway-vdp/ingress.yaml
+++ b/charts/vdp/templates/api-gateway-vdp/ingress.yaml
@@ -8,7 +8,7 @@ kind: BackendConfig
 metadata:
   name: vdp-backend-config
 spec:
-  timeoutSec: 60
+  timeoutSec: 300
 {{- else }}
 {{- $_ := set . "rootPath" "/" -}}
 {{- end }}


### PR DESCRIPTION
Because

- the 60 secs timeout is too short for pipeline trigger endpoint

This commit

- increase ingress timeout
