### PR TITLE
chore(helm): make connector k8s copy-docker step optional

### DIFF
--- a/charts/vdp/templates/connector-backend/deployment.yaml
+++ b/charts/vdp/templates/connector-backend/deployment.yaml
@@ -90,6 +90,7 @@ spec:
           {{- if .Values.connectorBackend.extraEnv }}
             {{- toYaml .Values.connectorBackend.extraEnv | nindent 12 }}
           {{- end }}
+        {{- if .Values.connectorBackend.copyHostDocker }}
         - name: copy-docker
           image: alpine:3.14
           imagePullPolicy: IfNotPresent
@@ -106,6 +107,7 @@ spec:
             runAsUser: 0
             runAsGroup: 0
             privileged: true
+        {{- end }}
         - name: wait-for-dependencies
           image: curlimages/curl:8.00.1
           command: ['sh', '-c']

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -344,6 +344,7 @@ connectorBackend:
     spec:
       minAvailable:
       maxUnavailable:
+  copyHostDocker: false
 controllerVDP:
   # -- The image of controller
   image:


### PR DESCRIPTION
Because

- the k8s copy-docker initContainer should be optional 

This commit

- make copy-docker step optional
