### PR TITLE
chore(makefile,env): rename `EXTRA_PARAMS` to `DOCKER_HELM_IT_EXTRA_PARAMS`

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,9 @@ COMPOSE_PROJECT_NAME=instill-vdp
 # configuration directory path for docker build
 BUILD_CONFIG_DIR_PATH=.
 
+# extra parameters for helm integration test running in docker
+DOCKER_HELM_IT_EXTRA_PARAMS=
+
 # flag to enable usage collection
 USAGE_ENABLED=true
 

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,6 @@ CONTAINER_BACKEND_INTEGRATION_TEST_NAME := vdp-backend-integration-test
 HELM_NAMESPACE := instill-ai
 HELM_RELEASE_NAME := vdp
 
-ifeq ($(UNAME_S),Darwin)
-EXTRA_PARAMS :=
-else ifeq ($(UNAME_S),Linux)
-EXTRA_PARAMS := -v ${HOME}/.minikube/:${HOME}/.minikube/ --network host
-endif
-
 #============================================================================
 
 .PHONY: all
@@ -243,7 +237,8 @@ helm-integration-test-latest:                       ## Run integration test on t
 		-v ${HOME}/.kube/config:/root/.kube/config \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
-		${EXTRA_PARAMS} --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
+		${DOCKER_HELM_IT_EXTRA_PARAMS} \
+		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
 			cp /instill-ai/base/.env $${TMP_CONFIG_DIR}/.env && \
 			cp /instill-ai/base/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
@@ -288,7 +283,8 @@ endif
 	@helm uninstall ${HELM_RELEASE_NAME} --namespace ${HELM_NAMESPACE}
 	@docker run -it --rm \
 		-v ${HOME}/.kube/config:/root/.kube/config \
-		${EXTRA_PARAMS} --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
+		${DOCKER_HELM_IT_EXTRA_PARAMS} \
+		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
 			/bin/bash -c 'cd /instill-ai/base && helm uninstall base --namespace ${HELM_NAMESPACE}' \
 		"
@@ -301,7 +297,8 @@ helm-integration-test-release:                       ## Run integration test on 
 	@make build-release
 	@docker run -it --rm \
 		-v ${HOME}/.kube/config:/root/.kube/config \
-		${EXTRA_PARAMS} --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
+		${DOCKER_HELM_IT_EXTRA_PARAMS} \
+		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
 			/bin/bash -c 'cd /instill-ai/base && \
 				export $(grep -v '^#' .env | xargs) && \
@@ -341,7 +338,8 @@ endif
 	@helm uninstall ${HELM_RELEASE_NAME} --namespace ${HELM_NAMESPACE}
 	@docker run -it --rm \
 		-v ${HOME}/.kube/config:/root/.kube/config \
-		${EXTRA_PARAMS} --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
+		${DOCKER_HELM_IT_EXTRA_PARAMS} \
+		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
 			/bin/bash -c 'cd /instill-ai/base && helm uninstall base --namespace ${HELM_NAMESPACE}' \
 		"


### PR DESCRIPTION
Because

- the original `EXTRA_PARAMS` is hard-coded for linux.

This commit

- rename `EXTRA_PARAMS` to `DOCKER_HELM_IT_EXTRA_PARAMS`
- put `DOCKER_HELM_IT_EXTRA_PARAMS` in `.env` to have a better extensibility
