### PR TITLE
ci(workflow): add integration-test-latest|release workflow for mac

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 jobs:
-  helm-integration-test-latest:
+  helm-integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
     steps:
@@ -96,6 +96,122 @@ jobs:
             --set connectorBackend.image.tag=latest \
             --set controllerVDP.image.tag=latest \
             --set tags.observability=false
+          kubectl rollout status deployment vdp-connector-backend --namespace instill-ai
+          kubectl rollout status deployment vdp-pipeline-backend --namespace instill-ai
+          kubectl rollout status deployment vdp-controller-vdp --namespace instill-ai
+          sleep 10
+
+      - name: Run ${{ inputs.component }} integration test (latest)
+        if: inputs.target == 'latest'
+        run: |
+          git clone https://github.com/instill-ai/${{ inputs.component }}.git
+          cd ${{ inputs.component }}
+          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+  helm-integration-test-latest-mac:
+    if: inputs.target == 'latest'
+    runs-on: [self-hosted,macOS,vdp]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install make
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Check if VDP Helm release exists
+        id: check-vdp-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'vdp'; then
+            echo "Helm release 'vdp' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'vdp' not found."
+          fi
+
+      - name: Uninstall VDP Helm Release
+        if: steps.check-vdp-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall vdp --namespace instill-ai
+
+      - name: Install k6
+        run: |
+          brew install k6
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Check if Base Helm release exists
+        id: check-base-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'base'; then
+            echo "Helm release 'base' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'base' not found."
+          fi
+
+      - name: Uninstall Base Helm Release
+        if: steps.check-base-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai
+
+      - name: Launch Helm Instill Base (latest)
+        run: |
+          helm install base charts/base --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set apiGateway.image.tag=latest \
+            --set mgmtBackend.image.tag=latest \
+            --set console.image.tag=latest \
+            --set tags.observability=false
+
+      - name: Wait for base pods up
+        run: |
+          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
+            echo "$(kubectl get pods --namespace instill-ai)"
+            sleep 10
+          done
+
+      - name: Port-forward of api-gateway
+        run: |
+          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
+          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill VDP (latest)
+        run: |
+          make build-latest
+          helm install vdp charts/vdp --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set pipelineBackend.image.tag=latest \
+            --set connectorBackend.image.tag=latest \
+            --set controllerVDP.image.tag=latest \
+            --set tags.observability=false
           kubectl rollout status deployment vdp-connector-backend --namespace instill-ai --timeout=120s
           kubectl rollout status deployment vdp-pipeline-backend --namespace instill-ai --timeout=120s
           kubectl rollout status deployment vdp-controller-vdp --namespace instill-ai --timeout=120s
@@ -108,7 +224,13 @@ jobs:
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
-  helm-integration-test-release:
+      - name: Uninstall Base and VDP Helm Release
+        run: |
+          helm uninstall vdp --namespace instill-ai
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai    
+
+  helm-integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
     steps:
@@ -158,8 +280,9 @@ jobs:
           helm install base charts/base --namespace instill-ai --create-namespace \
             --set edition=k8s-ce:test \
             --set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
-            --set console.image.tag=${CONSOLE_VERSION} \
-            --set tags.observability=false
+            --set apiGateway.image.tag=${API_GATEWAY_VERSION} \
+            --set tags.observability=false \
+            --set tags.prometheusStack=false            
 
       - name: Wait for base pods up
         run: |
@@ -197,6 +320,128 @@ jobs:
             --set connectorBackend.image.tag=${CONNECTOR_BACKEND_VERSION} \
             --set controllerVDP.image.tag=${CONTROLLER_VDP_VERSION} \
             --set tags.observability=false
+          kubectl rollout status deployment vdp-connector-backend --namespace instill-ai
+          kubectl rollout status deployment vdp-pipeline-backend --namespace instill-ai
+          kubectl rollout status deployment vdp-controller-vdp --namespace instill-ai
+          sleep 10
+
+      - name: Run ${{ inputs.component }} integration test (release)
+        env:
+          COMPONENT_VERSION: ${{ env[format('{0}_VERSION', steps.uppercase.outputs.COMPONENT_NAME)] }}
+        run: |
+          git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
+          cd ${{ inputs.component }}
+          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+  helm-integration-test-release-mac:
+    if: inputs.target == 'release'
+    runs-on: [self-hosted,macOS,vdp]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install make
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Check if VDP Helm release exists
+        id: check-vdp-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'vdp'; then
+            echo "Helm release 'vdp' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'vdp' not found."
+          fi
+
+      - name: Uninstall VDP Helm Release
+        if: steps.check-vdp-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall vdp --namespace instill-ai
+
+      - name: Install k6
+        run: |
+          brew install k6
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Check if Base Helm release exists
+        id: check-base-helm-release
+        run: |
+          if helm ls -n instill-ai | grep -q 'base'; then
+            echo "Helm release 'base' found."
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Helm release 'base' not found."
+          fi
+
+      - name: Uninstall Base Helm Release
+        if: steps.check-base-helm-release.outputs.release_exists == 'true'
+        run: |
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai
+
+      - name: Launch Helm Instill Base (release)
+        run: |
+          helm install base charts/base --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set apiGateway.image.tag=${API_GATEWAY_VERSION} \
+            --set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
+            --set tags.observability=false \
+            --set tags.prometheusStack=false
+
+      - name: Wait for base pods up
+        run: |
+          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
+            echo "$(kubectl get pods --namespace instill-ai)"
+            sleep 10
+          done
+
+      - name: Port-forward of base-api-gateway
+        run: |
+          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
+          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Uppercase component name
+        id: uppercase
+        run: |
+          echo "COMPONENT_NAME=$(echo ${{ inputs.component }} | tr 'a-z-' 'A-Z_')" >> $GITHUB_OUTPUT
+
+      - name: Launch Helm Instill VDP (release)
+        run: |
+          make build-release
+          helm install vdp charts/vdp --namespace instill-ai --create-namespace \
+            --set edition=k8s-ce:test \
+            --set pipelineBackend.image.tag=${PIPELINE_BACKEND_VERSION} \
+            --set connectorBackend.image.tag=${CONNECTOR_BACKEND_VERSION} \
+            --set controllerVDP.image.tag=${CONTROLLER_VDP_VERSION} \
+            --set tags.observability=false
           kubectl rollout status deployment vdp-connector-backend --namespace instill-ai --timeout=120s
           kubectl rollout status deployment vdp-pipeline-backend --namespace instill-ai --timeout=120s
           kubectl rollout status deployment vdp-controller-vdp --namespace instill-ai --timeout=120s
@@ -209,3 +454,9 @@ jobs:
           git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+      - name: Uninstall Base and VDP Helm Release
+        run: |
+          helm uninstall vdp --namespace instill-ai
+          helm uninstall base --namespace instill-ai
+          kubectl delete namespace instill-ai

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 jobs:
-  integration-test-latest:
+  integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
     steps:
@@ -88,7 +88,120 @@ jobs:
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
-  integration-test-release:
+  integration-test-latest-mac:
+    if: inputs.target == 'latest'
+    runs-on: [self-hosted,macOS,vdp]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install make
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Make down vdp
+        run: |
+          docker rm -f vdp-build-latest >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f vdp-dind-latest >/dev/null 2>&1
+          EDITION=NULL docker compose down -v
+          sleep 60
+
+      - name: Install k6
+        run: |
+          brew install k6
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Make down base
+        run: |
+          docker rm -f base-build-latest >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f base-console-integration-test-latest >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f base-console-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f base-dind-latest >/dev/null 2>&1
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60
+
+      - name: Launch Instill Base (latest)
+        run: |
+          make build-latest
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Launch Instill VDP (latest)
+        run: |
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+          COMPOSE_PROFILES=all \
+          EDITION=local-ce:test \
+          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+
+      - name: Run ${{ inputs.component }} integration test (latest)
+        if: inputs.target == 'latest'
+        run: |
+          git clone https://github.com/instill-ai/${{ inputs.component }}.git
+          cd ${{ inputs.component }}
+          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+      - name: Make down vdp
+        run: |
+          docker rm -f vdp-build-latest >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f vdp-dind-latest >/dev/null 2>&1
+          EDITION=NULL docker compose down -v
+          sleep 60
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Make down base
+        run: |
+          docker rm -f base-build-latest >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-latest >/dev/null 2>&1
+          docker rm -f base-console-integration-test-latest >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f base-console-integration-test-helm-latest >/dev/null 2>&1
+          docker rm -f base-dind-latest >/dev/null 2>&1
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60    
+
+  integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
     steps:
@@ -166,3 +279,118 @@ jobs:
           git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+  integration-test-release-mac:
+    if: inputs.target == 'release'
+    runs-on: [self-hosted,macOS,vdp]
+    steps:
+      - name: Set up environment
+        run: |
+          brew install make
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Make down vdp
+        run: |
+          docker rm -f vdp-build-release >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f vdp-dind-release >/dev/null 2>&1
+          EDITION=NULL docker compose down -v
+          sleep 60
+
+      - name: Install k6
+        run: |
+          brew install k6
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Make down base
+        run: |
+          docker rm -f base-build-release >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f base-console-integration-test-release >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f base-console-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f base-dind-release >/dev/null 2>&1
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60
+
+      - name: Launch Instill Base (release)
+        run: |
+          make build-release
+          EDITION=local-ce:test \
+          docker compose up -d --quiet-pull
+          EDITION=local-ce:test \
+          docker compose rm -f
+
+      - name: Checkout repo (vdp)
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/vdp
+
+      - name: Load .env file (vdp)
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Uppercase component name
+        id: uppercase
+        run: |
+          echo "COMPONENT_NAME=$(echo ${{ inputs.component }} | tr 'a-z-' 'A-Z_')" >> $GITHUB_OUTPUT
+
+      - name: Launch Instill VDP (release)
+        run: |
+          EDITION=local-ce:test \
+          docker compose up -d --quiet-pull
+          EDITION=local-ce:test \
+          docker compose rm -f
+
+      - name: Run ${{ inputs.component }} integration test (release)
+        env:
+          COMPONENT_VERSION: ${{ env[format('{0}_VERSION', steps.uppercase.outputs.COMPONENT_NAME)] }}
+        run: |
+          git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
+          cd ${{ inputs.component }}
+          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+
+      - name: Make down vdp
+        run: |
+          docker rm -f vdp-build-release >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f vdp-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f vdp-dind-release >/dev/null 2>&1
+          EDITION=NULL docker compose down -v
+          sleep 60
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: instill-ai/base
+
+      - name: Make down base
+        run: |
+          docker rm -f base-build-release >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-release >/dev/null 2>&1
+          docker rm -f base-console-integration-test-release >/dev/null 2>&1
+          docker rm -f base-backend-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f base-console-integration-test-helm-release >/dev/null 2>&1
+          docker rm -f base-dind-release >/dev/null 2>&1
+          EDITION=NULL docker compose -f docker-compose.yml -f docker-compose.observe.yml down -v
+          sleep 60

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ integration-test-release:			## Run integration test on the release VDP
 
 .PHONY: helm-integration-test-latest
 helm-integration-test-latest:                       ## Run integration test on the Helm latest for VDP
-	@make all EDITION=local-ce:test
+	@make build-latest
 	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run --rm \
 		-v ${HOME}/.kube/config:/root/.kube/config \
 		-v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
Because

- We have to automate make integration-test-latest|release and helm-integration-test-latest|release for mac

This commit

- add integration-test-latest|release workflow for mac
