### PR TITLE
chore(helm): update pipeline db version

### DIFF
--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -215,7 +215,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 3
+  dbVersion: 4
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- the pipeline-backend db version has been upgraded

This commit

- upgrade pipeline db version
