### PR TITLE
chore(helm): add annotations for pipeline-backend deployment

### DIFF
--- a/charts/vdp/templates/pipeline-backend/deployment.yaml
+++ b/charts/vdp/templates/pipeline-backend/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/component: pipeline-backend
   annotations:
     rollme: {{ randAlphaNum 5 | quote }}
+    {{- with .Values.pipelineBackend.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -207,6 +207,8 @@ pipelineBackend:
     repository: instill/pipeline-backend
     tag: 0.14.1-alpha
     pullPolicy: IfNotPresent
+  # -- Annotation for deployment
+  annotations: {}
   # -- The command names to be executed
   commandName:
     migration: pipeline-backend-migrate


### PR DESCRIPTION
Because

- we need annotations for pipeline-backend for secret updation. 

This commit

- add annotations for pipeline-backend deployment.
