### PR TITLE
chore(helm): enable flag for api-gateway

### DIFF
--- a/charts/vdp/templates/api-gateway-vdp/configmap.yaml
+++ b/charts/vdp/templates/api-gateway-vdp/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.apiGatewayVDP.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -38,3 +39,4 @@ data:
     JAEGER_ENABLE={{ .Values.tags.observability }}
     JAEGER_HOST={{ template "base.jaeger" . }}
     JAEGER_PORT={{ template "base.jaeger.port" . }}
+{{- end }}

--- a/charts/vdp/templates/api-gateway-vdp/deployment.yaml
+++ b/charts/vdp/templates/api-gateway-vdp/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.apiGatewayVDP.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -167,3 +168,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/vdp/templates/api-gateway-vdp/ingress.yaml
+++ b/charts/vdp/templates/api-gateway-vdp/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.expose.ingress.enabled }}
 {{- if eq .Values.expose.type "ingress" }}
 {{- $ingress := .Values.expose.ingress -}}
 {{- $tls := .Values.expose.tls -}}
@@ -63,4 +64,5 @@ spec:
     {{- if $ingress.hosts.apiGatewayVDP }}
     host: {{ $ingress.hosts.apiGatewayVDP }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/vdp/templates/api-gateway-vdp/service.yaml
+++ b/charts/vdp/templates/api-gateway-vdp/service.yaml
@@ -1,3 +1,4 @@
+{{- if or ( .Values.expose.clusterIP.enabled ) ( .Values.expose.nodePort.enabled ) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -87,3 +88,4 @@ spec:
   selector:
     {{- include "vdp.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: api-gateway-vdp
+{{- end }}

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -42,6 +42,7 @@ expose:
       # "tls.key" - the private key
       secretName: ""
   ingress:
+    enabled: false
     hosts:
       apiGatewayVDP: api-vdp.instill.tech
     # set to the type of ingress controller if it has specific requirements.
@@ -54,6 +55,7 @@ expose:
     # Annotations on the Ingress
     annotations: {}
   clusterIP:
+    enabled: false
     ports:
       # The service port api-gateway http listens on
       apiGatewayVDPHttp:
@@ -64,6 +66,7 @@ expose:
     # Annotations on the ClusterIP service
     annotations: {}
   nodePort:
+    enabled: false
     ports:
       apiGatewayVDPHttp:
         # The service port api-gateway http listens on
@@ -146,6 +149,7 @@ usage:
   host: usage.instill.tech
   port: 443
 apiGatewayVDP:
+  enabled: false
   # -- The image of api-gateway
   image:
     repository: instill/api-gateway


### PR DESCRIPTION
Because

- We have to consolidate the api-gateway of vdp and model into the base for that we need to add enable flag. 

This commit

- add enable flag into api-gateway
