### PR TITLE
ci(Makefile): optimise spin-up/tear-down flow

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # docker compose project name
 COMPOSE_PROJECT_NAME=instill-vdp
 
-# system-wise config path
+# system-wise config path (all base, vdp, and model projects must use the same path)
 SYSTEM_CONFIG_PATH=~/.config/instill
 
 # configuration directory path for docker build
@@ -24,7 +24,6 @@ DOCKER_BUILDKIT=1
 COMPOSE_DOCKER_CLI_BUILD=1
 
 # version
-UBUNTU_VERSION=20.04
 ALPINE_VERSION=3.16
 
 GOLANG_VERSION=1.19.3
@@ -33,7 +32,7 @@ ARTIVC_VERSION=0.10.0
 K6_VERSION=0.44.0
 
 # Instill Base
-BASE_VERSION=0.3.0-alpha
+INSTILL_BASE_VERSION=0.3.0-alpha
 
 # api-gateway
 API_GATEWAY_HOST=api-gateway

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -1,7 +1,11 @@
-name: Make all
+name: Make All
 
 on:
   workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   make-all:
@@ -35,24 +39,6 @@ jobs:
           rm --recursive --force "$AGENT_TOOLSDIRECTORY"
           df --human-readable
 
-      - name: Checkout repo (base)
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/base
-
-      - name: Load .env file (base)
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Launch Instill Base (release)
-        run: |
-          EDITION=local-ce \
-          DEFAULT_USER_UID=${DEFAULT_USER_UID} \
-          docker compose -f docker-compose.yml up -d --quiet-pull
-          EDITION=local-ce \
-          docker compose -f docker-compose.yml rm -f
-
       - name: Checkout repo (vdp)
         uses: actions/checkout@v3
         with:
@@ -65,24 +51,19 @@ jobs:
 
       - name: Launch Instill VDP (release)
         run: |
-          EDITION=local-ce \
-          docker compose -f docker-compose.yml up -d --quiet-pull
-          EDITION=local-ce \
-          docker compose -f docker-compose.yml rm -f
+          make all EDITION=local-ce:test
 
       - name: List all docker containers
         run: |
           docker ps -a
           sleep 60
 
-      - name: Curl to base (influxdb, temporal and console) healthcheck endpoint
-        run: |
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8086/health
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8088/health
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3000
-
-      - name: Curl to vdp services healthcheck endpoint
+      - name: Probe to vdp services healthcheck endpoint
         run: |
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/base/v1alpha/health/mgmt
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/vdp/v1alpha/health/pipeline
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/vdp/v1alpha/health/connector
+
+      - name: Tear down Instill VDP (release)
+        run: |
+          make down

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -1,7 +1,11 @@
-name: Make latest
+name: Make Latest
 
 on:
   workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   make-latest:
@@ -35,27 +39,6 @@ jobs:
           rm --recursive --force "$AGENT_TOOLSDIRECTORY"
           df --human-readable
 
-      - name: Checkout repo (base)
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/base
-
-      - name: Load .env file (base)
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Launch Instill Base (latest)
-        run: |
-          echo ${DEFAULT_USER_UID}
-          COMPOSE_PROFILES=all \
-          DEFAULT_USER_UID=${DEFAULT_USER_UID} \
-          EDITION=local-ce:latest \
-          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
-          COMPOSE_PROFILES=all \
-          EDITION=local-ce:latest \
-          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
-
       - name: Checkout repo (vdp)
         uses: actions/checkout@v3
         with:
@@ -68,24 +51,12 @@ jobs:
 
       - name: Launch Instill VDP (latest)
         run: |
-          COMPOSE_PROFILES=all \
-          EDITION=local-ce:latest \
-          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
-          COMPOSE_PROFILES=all \
-          EDITION=local-ce:latest \
-          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+          make latest PROFILE=all EDITION=local-ce:test
 
       - name: List all docker containers
         run: |
           docker ps -a
           sleep 30
-
-      - name: Curl to base (influxdb, temporal, console and etcd) healthcheck endpoint
-        run: |
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8086/health
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8088/health
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3000
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3379/health
 
       - name: Curl to vdp services healthcheck endpoint
         run: |
@@ -93,3 +64,7 @@ jobs:
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/vdp/v1alpha/health/pipeline
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/vdp/v1alpha/health/connector
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3085/v1alpha/health/controller
+
+      - name: Tear down Instill VDP (latest)
+        run: |
+          make down

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,7 @@
-ARG UBUNTU_VERSION
-FROM ubuntu:${UBUNTU_VERSION} AS base
+ARG ALPINE_VERSION
+FROM alpine:${ALPINE_VERSION} AS base
 
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get -y install \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release
-
-RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-RUN echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-RUN apt-get update && apt-get install -y \
-    docker-ce \
-    docker-ce-cli \
-    containerd.io \
-    docker-compose-plugin \
-    git \
-    bash \
-    make \
-    wget \
-    vim && rm -rf /var/lib/apt/lists/*
+RUN apk add --update docker docker-compose docker-cli-compose docker-cli-buildx openrc containerd git bash make wget vim curl openssl
 
 # Install k6
 ARG TARGETARCH K6_VERSION
@@ -38,10 +16,11 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin
 
-FROM ubuntu:${UBUNTU_VERSION} AS latest
+FROM alpine:${ALPINE_VERSION} AS latest
 
 COPY --from=base /etc /etc
 COPY --from=base /usr /usr
+COPY --from=base /lib /lib
 COPY --from=docker:dind /usr/local/bin /usr/local/bin
 
 ARG CACHE_DATE
@@ -57,10 +36,11 @@ RUN git clone https://github.com/instill-ai/pipeline-backend.git
 RUN git clone https://github.com/instill-ai/connector-backend.git
 RUN git clone https://github.com/instill-ai/controller-vdp.git
 
-FROM ubuntu:${UBUNTU_VERSION} AS release
+FROM alpine:${ALPINE_VERSION} AS release
 
 COPY --from=base /etc /etc
 COPY --from=base /usr /usr
+COPY --from=base /lib /lib
 COPY --from=docker:dind /usr/local/bin /usr/local/bin
 
 ARG CACHE_DATE
@@ -68,8 +48,8 @@ RUN echo "VDP release codebase cloned on ${CACHE_DATE}"
 
 WORKDIR /instill-ai
 
-ARG BASE_VERSION
-RUN git clone -b v${BASE_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/base.git
+ARG INSTILL_BASE_VERSION
+RUN git clone -b v${INSTILL_BASE_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/base.git
 
 WORKDIR /instill-ai/vdp
 

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,6 @@ CONTAINER_BACKEND_INTEGRATION_TEST_NAME := vdp-backend-integration-test
 HELM_NAMESPACE := instill-ai
 HELM_RELEASE_NAME := vdp
 
-# check or generate uuid for user
-ifeq ($(wildcard ${SYSTEM_CONFIG_PATH}/user_uid),)
-$(shell mkdir -p ${SYSTEM_CONFIG_PATH})
-$(shell docker run --rm andyneff/uuidgen > ${SYSTEM_CONFIG_PATH}/user_uid)
-endif
-DEFAULT_USER_UID := $(shell cat ${SYSTEM_CONFIG_PATH}/user_uid)
-
 #============================================================================
 
 .PHONY: all
@@ -30,46 +23,46 @@ all:			## Launch all services with their up-to-date release version
 	@make build-release
 	@if ! (docker compose ls -q | grep -q "instill-base"); then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
-		docker run -it --rm \
+		export SYSTEM_CONFIG_PATH=$(shell eval echo ${SYSTEM_CONFIG_PATH}) && \
+		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
+			-v $${SYSTEM_CONFIG_PATH}:$${SYSTEM_CONFIG_PATH} \
 			--name ${CONTAINER_COMPOSE_NAME}-release \
-			${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/bash -c " \
+			${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
 				cp /instill-ai/base/.env $${TMP_CONFIG_DIR}/.env && \
 				cp /instill-ai/base/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
 				cp -r /instill-ai/base/configs/influxdb $${TMP_CONFIG_DIR} && \
-				/bin/bash -c 'cd /instill-ai/base && make build-release BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
-				/bin/bash -c 'cd /instill-ai/base && DEFAULT_USER_UID=${DEFAULT_USER_UID} EDITION=local-ce:test OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} docker compose up -d --quiet-pull' && \
-				/bin/bash -c 'cd /instill-ai/base && EDITION=local-ce:test OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} docker compose rm -f' && \
-				/bin/bash -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
+				/bin/sh -c 'cd /instill-ai/base && make all EDITION=$${EDITION:=local-ce} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
+				rm -rf $${TMP_CONFIG_DIR}/* \
 			" && \
 		rm -rf $${TMP_CONFIG_DIR}; \
 	fi
-	@EDITION=local-ce docker compose -f docker-compose.yml up -d --quiet-pull
-	@EDITION=local-ce docker compose -f docker-compose.yml rm -f
+	@EDITION=$${EDITION:=local-ce} docker compose -f docker-compose.yml up -d --quiet-pull
+	@EDITION=$${EDITION:=local-ce} docker compose -f docker-compose.yml rm -f
 
 .PHONY: latest
 latest:			## Lunch all dependent services with their latest codebase
 	@make build-latest
 	@if ! (docker compose ls -q | grep -q "instill-base"); then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
-		docker run -it --rm \
+		export SYSTEM_CONFIG_PATH=$(shell eval echo ${SYSTEM_CONFIG_PATH}) && \
+		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
+			-v $${SYSTEM_CONFIG_PATH}:$${SYSTEM_CONFIG_PATH} \
 			--name ${CONTAINER_COMPOSE_NAME}-latest \
-			${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
+			${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
 				cp /instill-ai/base/.env $${TMP_CONFIG_DIR}/.env && \
 				cp /instill-ai/base/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
 				cp -r /instill-ai/base/configs/influxdb $${TMP_CONFIG_DIR} && \
-				/bin/bash -c 'cd /instill-ai/base && make build-latest BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
-				/bin/bash -c 'cd /instill-ai/base && DEFAULT_USER_UID=${DEFAULT_USER_UID} COMPOSE_PROFILES=all EDITION=local-ce:test OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull' && \
-				/bin/bash -c 'cd /instill-ai/base && COMPOSE_PROFILES=all EDITION=local-ce:test OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f' && \
-				/bin/bash -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
+				/bin/sh -c 'cd /instill-ai/base && make latest PROFILE=all EDITION=$${EDITION:=local-ce:latest} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH} OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}'&& \
+				rm -rf $${TMP_CONFIG_DIR}/* \
 			" && \
 		rm -rf $${TMP_CONFIG_DIR}; \
 	fi
-	@COMPOSE_PROFILES=$(PROFILE) EDITION=local-ce:latest docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
-	@COMPOSE_PROFILES=$(PROFILE) EDITION=local-ce:latest docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+	@COMPOSE_PROFILES=$(PROFILE) EDITION=$${EDITION:=local-ce:latest} docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+	@COMPOSE_PROFILES=$(PROFILE) EDITION=$${EDITION:=local-ce:latest} docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
 
 .PHONY: logs
 logs:			## Tail all logs with -n 10
@@ -105,14 +98,23 @@ down:			## Stop all services and remove all service containers and volumes
 	@docker rm -f ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release >/dev/null 2>&1
 	@docker rm -f ${CONTAINER_COMPOSE_NAME}-latest >/dev/null 2>&1
 	@docker rm -f ${CONTAINER_COMPOSE_NAME}-release >/dev/null 2>&1
-	@docker compose down -v
+	@EDITION=NULL docker compose down -v
 	@if docker compose ls -q | grep -q "instill-base"; then \
-		docker run -it --rm \
-			-v /var/run/docker.sock:/var/run/docker.sock \
-			--name ${CONTAINER_COMPOSE_NAME} \
-			${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-				/bin/bash -c 'cd /instill-ai/base && make down' \
-			"; \
+		if docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:latest >/dev/null 2>&1; then \
+			docker run --rm \
+				-v /var/run/docker.sock:/var/run/docker.sock \
+				--name ${CONTAINER_COMPOSE_NAME} \
+				${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
+					/bin/sh -c 'cd /instill-ai/base && make down' \
+				"; \
+		elif docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:release >/dev/null 2>&1; then \
+			docker run --rm \
+				-v /var/run/docker.sock:/var/run/docker.sock \
+				--name ${CONTAINER_COMPOSE_NAME} \
+				${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+					/bin/sh -c 'cd /instill-ai/base && make down' \
+				"; \
+		fi	\
 	fi
 
 .PHONY: images
@@ -134,18 +136,18 @@ doc:						## Run Redoc for OpenAPI spec at http://localhost:3001
 .PHONY: build-latest
 build-latest:				## Build latest images for all VDP components
 	@docker build --progress plain \
-		--build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
+		--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
 		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
 		--build-arg K6_VERSION=${K6_VERSION} \
 		--build-arg CACHE_DATE="$(shell date)" \
 		--target latest \
 		-t ${CONTAINER_COMPOSE_IMAGE_NAME}:latest .
-	@docker run -it --rm \
+	@docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v ${BUILD_CONFIG_DIR_PATH}/.env:/instill-ai/vdp/.env \
 		-v ${BUILD_CONFIG_DIR_PATH}/docker-compose.build.yml:/instill-ai/vdp/docker-compose.build.yml \
 		--name ${CONTAINER_BUILD_NAME}-latest \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
 			PIPELINE_BACKEND_VERSION=latest \
 			CONNECTOR_BACKEND_VERSION=latest \
 			CONTROLLER_VDP_VERSION=latest \
@@ -155,23 +157,23 @@ build-latest:				## Build latest images for all VDP components
 .PHONY: build-release
 build-release:				## Build release images for all VDP components
 	@docker build --progress plain \
-		--build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
+		--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
 		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
 		--build-arg K6_VERSION=${K6_VERSION} \
 		--build-arg CACHE_DATE="$(shell date)" \
-		--build-arg BASE_VERSION=${BASE_VERSION} \
+		--build-arg INSTILL_BASE_VERSION=${INSTILL_BASE_VERSION} \
 		--build-arg PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_VERSION} \
 		--build-arg CONNECTOR_BACKEND_VERSION=${CONNECTOR_BACKEND_VERSION} \
 		--build-arg CONTROLLER_VDP_VERSION=${CONTROLLER_VDP_VERSION} \
 		--target release \
 		-t ${CONTAINER_COMPOSE_IMAGE_NAME}:release .
-	@docker run -it --rm \
+	@docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v ${BUILD_CONFIG_DIR_PATH}/.env:/instill-ai/vdp/.env \
 		-v ${BUILD_CONFIG_DIR_PATH}/docker-compose.build.yml:/instill-ai/vdp/docker-compose.build.yml \
 		--name ${CONTAINER_BUILD_NAME}-release \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/bash -c " \
-			BASE_VERSION=${BASE_VERSION} \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+			INSTILL_BASE_VERSION=${INSTILL_BASE_VERSION} \
 			PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_VERSION} \
 			CONNECTOR_BACKEND_VERSION=${CONNECTOR_BACKEND_VERSION} \
 			CONTROLLER_VDP_VERSION=${CONTROLLER_VDP_VERSION} \
@@ -180,74 +182,44 @@ build-release:				## Build release images for all VDP components
 
 .PHONY: integration-test-latest
 integration-test-latest:			## Run integration test on the latest VDP
-	@make build-latest
-	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run -it --rm \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
-		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-			cp /instill-ai/base/.env $${TMP_CONFIG_DIR}/.env && \
-			cp /instill-ai/base/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
-			cp -r /instill-ai/base/configs/influxdb $${TMP_CONFIG_DIR} && \
-			/bin/bash -c 'cd /instill-ai/base && make build-latest BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
-			/bin/bash -c 'cd /instill-ai/base && COMPOSE_PROFILES=all EDITION=local-ce:test OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull' && \
-			/bin/bash -c 'cd /instill-ai/base && COMPOSE_PROFILES=all EDITION=local-ce:test OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f' && \
-			/bin/bash -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
-		" && rm -rf $${TMP_CONFIG_DIR}
-	@COMPOSE_PROFILES=all EDITION=local-ce:test docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
-	@COMPOSE_PROFILES=all EDITION=local-ce:test docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
-	@docker run -it --rm \
+	@make latest PROFILE=all EDITION=local-ce:test
+	@docker run --rm \
 		--network instill-network \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-			/bin/bash -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd connector-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
+			/bin/sh -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd connector-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' \
 		"
 	@make down
 
 .PHONY: integration-test-release
 integration-test-release:			## Run integration test on the release VDP
-	@make build-release
-	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run -it --rm \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
-		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-release \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/bash -c " \
-			cp /instill-ai/base/.env $${TMP_CONFIG_DIR}/.env && \
-			cp /instill-ai/base/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
-			cp -r /instill-ai/base/configs/influxdb $${TMP_CONFIG_DIR} && \
-			/bin/bash -c 'cd /instill-ai/base && make build-release BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
-			/bin/bash -c 'cd /instill-ai/base && EDITION=local-ce:test OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} docker compose up -d --quiet-pull' && \
-			/bin/bash -c 'cd /instill-ai/base && EDITION=local-ce:test OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} docker compose rm -f' && \
-			/bin/bash -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
-		" && rm -rf $${TMP_CONFIG_DIR}
-	@EDITION=local-ce:test ITMODE_ENABLED=true docker compose up -d --quiet-pull
-	@EDITION=local-ce:test docker compose rm -f
-	@docker run -it --rm \
+	@make all EDITION=local-ce:test
+	@docker run --rm \
 		--network instill-network \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-release \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/bash -c " \
-			/bin/bash -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd connector-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+			/bin/sh -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd connector-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' \
 		"
 	@make down
 
 .PHONY: helm-integration-test-latest
 helm-integration-test-latest:                       ## Run integration test on the Helm latest for VDP
-	@make build-latest
-	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run -it --rm \
+	@make all EDITION=local-ce:test
+	@export TMP_CONFIG_DIR=$(shell mktemp -d) && docker run --rm \
 		-v ${HOME}/.kube/config:/root/.kube/config \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
 		${DOCKER_HELM_IT_EXTRA_PARAMS} \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
 			cp /instill-ai/base/.env $${TMP_CONFIG_DIR}/.env && \
 			cp /instill-ai/base/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
-			/bin/bash -c 'cd /instill-ai/base && make build-latest BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
-			/bin/bash -c 'cd /instill-ai/base && \
+			/bin/sh -c 'cd /instill-ai/base && make build-latest BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
+			/bin/sh -c 'cd /instill-ai/base && \
 				helm install base charts/base \
 					--namespace ${HELM_NAMESPACE} --create-namespace \
 					--set edition=k8s-ce:test \
@@ -256,7 +228,7 @@ helm-integration-test-latest:                       ## Run integration test on t
 					--set console.image.tag=latest \
 					--set tags.observability=false \
 					--set tags.prometheusStack=false' \
-			/bin/bash -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
+			/bin/sh -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
 		" && rm -rf $${TMP_CONFIG_DIR}
 	@kubectl rollout status deployment base-api-gateway --namespace ${HELM_NAMESPACE} --timeout=120s
 	@export API_GATEWAY_POD_NAME=$$(kubectl get pods --namespace ${HELM_NAMESPACE} -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o jsonpath="{.items[0].metadata.name}") && \
@@ -273,25 +245,25 @@ helm-integration-test-latest:                       ## Run integration test on t
 	@kubectl rollout status deployment vdp-controller-vdp --namespace ${HELM_NAMESPACE} --timeout=120s
 	@sleep 10
 ifeq ($(UNAME_S),Darwin)
-	@docker run -it --rm --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-latest ${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-			/bin/bash -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd connector-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' \
+	@docker run --rm --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-latest ${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
+			/bin/sh -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd connector-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' \
 		"
 else ifeq ($(UNAME_S),Linux)
-	@docker run -it --rm --network host --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-latest ${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-			/bin/bash -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd connector-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' \
+	@docker run --rm --network host --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-latest ${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
+			/bin/sh -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd connector-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' \
 		"
 endif
 	@helm uninstall ${HELM_RELEASE_NAME} --namespace ${HELM_NAMESPACE}
-	@docker run -it --rm \
+	@docker run --rm \
 		-v ${HOME}/.kube/config:/root/.kube/config \
 		${DOCKER_HELM_IT_EXTRA_PARAMS} \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-			/bin/bash -c 'cd /instill-ai/base && helm uninstall base --namespace ${HELM_NAMESPACE}' \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
+			/bin/sh -c 'cd /instill-ai/base && helm uninstall base --namespace ${HELM_NAMESPACE}' \
 		"
 	@kubectl delete namespace instill-ai
 	@pkill -f "port-forward"
@@ -300,12 +272,12 @@ endif
 .PHONY: helm-integration-test-release
 helm-integration-test-release:                       ## Run integration test on the Helm release for VDP
 	@make build-release
-	@docker run -it --rm \
+	@docker run --rm \
 		-v ${HOME}/.kube/config:/root/.kube/config \
 		${DOCKER_HELM_IT_EXTRA_PARAMS} \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-			/bin/bash -c 'cd /instill-ai/base && \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
+			/bin/sh -c 'cd /instill-ai/base && \
 				export $(grep -v '^#' .env | xargs) && \
 				helm install base charts/base \
 					--namespace ${HELM_NAMESPACE} --create-namespace \
@@ -314,8 +286,7 @@ helm-integration-test-release:                       ## Run integration test on 
 					--set edition=k8s-ce:test \
 					--set tags.observability=false \
 					--set tags.prometheusStack=false' \
-			/bin/bash -c 'rm -rf $${TMP_CONFIG_DIR}/*' \
-		" && rm -rf $${TMP_CONFIG_DIR}
+		"
 	@kubectl rollout status deployment base-api-gateway --namespace ${HELM_NAMESPACE} --timeout=120s
 	@export API_GATEWAY_POD_NAME=$$(kubectl get pods --namespace ${HELM_NAMESPACE} -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=base" -o jsonpath="{.items[0].metadata.name}") && \
 		kubectl --namespace ${HELM_NAMESPACE} port-forward $${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
@@ -331,25 +302,25 @@ helm-integration-test-release:                       ## Run integration test on 
 	@kubectl rollout status deployment vdp-controller-vdp --namespace ${HELM_NAMESPACE} --timeout=120s
 	@sleep 10
 ifeq ($(UNAME_S),Darwin)
-	@docker run -it --rm --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release ${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/bash -c " \
-			/bin/bash -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd connector-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' \
+	@docker run --rm --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release ${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+			/bin/sh -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd connector-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' \
 		"
 else ifeq ($(UNAME_S),Linux)
-	@docker run -it --rm --network host --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release ${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/bash -c " \
-			/bin/bash -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd connector-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
-			/bin/bash -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' \
+	@docker run --rm --network host --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release ${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+			/bin/sh -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd connector-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
+			/bin/sh -c 'cd controller-vdp && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' \
 		"
 endif
 	@helm uninstall ${HELM_RELEASE_NAME} --namespace ${HELM_NAMESPACE}
-	@docker run -it --rm \
+	@docker run --rm \
 		-v ${HOME}/.kube/config:/root/.kube/config \
 		${DOCKER_HELM_IT_EXTRA_PARAMS} \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-			/bin/bash -c 'cd /instill-ai/base && helm uninstall base --namespace ${HELM_NAMESPACE}' \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
+			/bin/sh -c 'cd /instill-ai/base && helm uninstall base --namespace ${HELM_NAMESPACE}' \
 		"
 	@kubectl delete namespace instill-ai
 	@pkill -f "port-forward"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ volumes:
     name: airbyte
 
 services:
-
   pipeline_backend_migrate:
     container_name: ${PIPELINE_BACKEND_HOST}-migrate
     image: ${PIPELINE_BACKEND_IMAGE}:${PIPELINE_BACKEND_VERSION}
@@ -34,7 +33,7 @@ services:
       CFG_SERVER_DEBUG: "false"
       CFG_SERVER_MAXDATASIZE: ${MAX_DATA_SIZE}
       CFG_SERVER_USAGE_ENABLED: ${USAGE_ENABLED}
-      CFG_SERVER_EDITION: ${EDITION:-local-ce:unknown}
+      CFG_SERVER_EDITION: ${EDITION}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres
@@ -63,7 +62,7 @@ services:
       CFG_SERVER_DEBUG: "false"
       CFG_SERVER_MAXDATASIZE: ${MAX_DATA_SIZE}
       CFG_SERVER_USAGE_ENABLED: ${USAGE_ENABLED}
-      CFG_SERVER_EDITION: ${EDITION:-local-ce:unknown}
+      CFG_SERVER_EDITION: ${EDITION}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres
@@ -122,7 +121,7 @@ services:
       CFG_SERVER_PUBLICPORT: ${CONNECTOR_BACKEND_PUBLICPORT}
       CFG_SERVER_DEBUG: "false"
       CFG_SERVER_USAGE_ENABLED: ${USAGE_ENABLED}
-      CFG_SERVER_EDITION: ${EDITION:-local-ce:unknown}
+      CFG_SERVER_EDITION: ${EDITION}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres
@@ -148,7 +147,7 @@ services:
     restart: unless-stopped
     environment:
       CFG_SERVER_DEBUG: "false"
-      CFG_SERVER_EDITION: ${EDITION:-local-ce:unknown}
+      CFG_SERVER_EDITION: ${EDITION}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres


### PR DESCRIPTION
Because

- `make down` won't go smoothly from a `make all` instance due to missing `release` compose images
-  the current 3rd-party `uuidgen` image doesn't support arm64

This commit

- replace the Ubuntu image with Apline to save ~300MB for the compose image
- add related `release` compose images in `make down`
- add `make down` step in `make-all/latest` GA workflow to validate the complete flow
- move `uuidgen` into compose image so we don't need to use an external image
- make `~/.config/instill` folder logic and env variable `SYSTEM_CONFIG_PATH` in only the base project