### PR TITLE
ci(Makefile): fix make stop and start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       CFG_SERVER_DEBUG: "false"
       CFG_SERVER_MAXDATASIZE: ${MAX_DATA_SIZE}
       CFG_SERVER_USAGE_ENABLED: ${USAGE_ENABLED}
-      CFG_SERVER_EDITION: ${EDITION:-}
+      CFG_SERVER_EDITION: ${EDITION}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres
@@ -62,7 +62,7 @@ services:
       CFG_SERVER_DEBUG: "false"
       CFG_SERVER_MAXDATASIZE: ${MAX_DATA_SIZE}
       CFG_SERVER_USAGE_ENABLED: ${USAGE_ENABLED}
-      CFG_SERVER_EDITION: ${EDITION:-}
+      CFG_SERVER_EDITION: ${EDITION}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres
@@ -121,7 +121,7 @@ services:
       CFG_SERVER_PUBLICPORT: ${CONNECTOR_BACKEND_PUBLICPORT}
       CFG_SERVER_DEBUG: "false"
       CFG_SERVER_USAGE_ENABLED: ${USAGE_ENABLED}
-      CFG_SERVER_EDITION: ${EDITION:-}
+      CFG_SERVER_EDITION: ${EDITION}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres
@@ -147,7 +147,7 @@ services:
     restart: unless-stopped
     environment:
       CFG_SERVER_DEBUG: "false"
-      CFG_SERVER_EDITION: ${EDITION:-}
+      CFG_SERVER_EDITION: ${EDITION}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres
@@ -169,7 +169,7 @@ services:
         target: /var/run/docker.sock
 
   temporal_admin_tools:
-    container_name: ${TEMPORAL_HOST}-admin-tools
+    container_name: temporal-admin-tools
     image: ${TEMPORAL_ADMIN_TOOLS_IMAGE}:${TEMPORAL_ADMIN_TOOLS_VERSION}
     restart: on-failure
     environment:


### PR DESCRIPTION
Because

- `make stop/start` was broken due to the containers used in docker compose `depends_on` that are removed after spin-up

This commit

- remove `docker compose rm -f` in `make all/latest`
- remove `make rm` and `make restart` (no use case)
- revert EDITION setting logic
