### PR TITLE
ci(release): update version in README automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ Execute the following commands to start pre-built images with all the dependenci
 
 **The stable release version**
 
+<!-- x-release-please-start-version -->
 ```bash
 $ git clone -b v0.14.0-alpha https://github.com/instill-ai/vdp.git && cd vdp
 
 # Launch all services
 $ make all
 ```
+<!-- x-release-please-end -->
 
 **The latest version for development**
 

--- a/release-please/config.json
+++ b/release-please/config.json
@@ -5,7 +5,10 @@
       "draft": false,
       "prerelease": true,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": false,
+      "extra-files": [
+        "README.md"
+      ]
     }
   }
 }


### PR DESCRIPTION
Because

- we need to update version in README automatically in case human error

This commit

- use release-please to update version in README automatically
