### PR TITLE
ci(Makefile): enhance Instill Core launch

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,13 @@
 # docker compose project name
 COMPOSE_PROJECT_NAME=instill-vdp
 
+# build from scratch or not at launch, which will build all sources from scrach. Default to false.
+BUILD=false
+
+# docker compose profiles to selectively launch components for developing the latest codebase of the specified component.
+# the value can be all, api-gateway, mgmt, pipeline, connector, controller-vdp, model, controller-model, or console.
+PROFILE=all
+
 # system-wise config path (all core, vdp, and model projects must use the same path)
 SYSTEM_CONFIG_PATH=$(HOME)/.config/instill
 

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Launch Instill VDP (release)
         run: |
-          make all EDITION=local-ce:test
+          make all BUILD=true EDITION=local-ce:test
 
       - name: List all docker containers
         run: |

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Launch Instill VDP (latest)
         run: |
-          make latest PROFILE=all EDITION=local-ce:test
+          make latest BUILD=true PROFILE=all EDITION=local-ce:test
 
       - name: List all docker containers
         run: |


### PR DESCRIPTION
Because

- the `core` repo is treated as the main Instill Core repo
- `make all/latest` now by default will launch all projects without building all components images from scratch
- `make all/latest PROJECT={core,vdp,model}` will launch the specified projects
- `make all/latest BUILD=true` will launch all projects and build all components from scratch
- `make down` will tear down everything in Instill Core
- `make all/latest {BUILD=true}` in the `vdp` and `model` repo will launch their dependent `core`
- `make down` in the `vdp` and `model` repo will tear down everything in Instill Core

This commit

- implement the above-mentioned logics
