### PR TITLE
ci(workflow): set time limit to workflow run

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -14,7 +14,11 @@ jobs:
   helm-integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -112,7 +116,11 @@ jobs:
   helm-integration-test-latest-mac:
     if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, vdp]
+    timeout-minutes: 20
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       - name: Set up environment
         run: |
           brew install make
@@ -235,7 +243,11 @@ jobs:
   helm-integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -339,7 +351,11 @@ jobs:
   helm-integration-test-release-mac:
     if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, vdp]
+    timeout-minutes: 20
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       - name: Set up environment
         run: |
           brew install make

--- a/.github/workflows/helm-integration-test-release.yml
+++ b/.github/workflows/helm-integration-test-release.yml
@@ -2,11 +2,6 @@ name: Helm Integration Test (release)
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-please--branches--main
-    tags:
-      - v*
 
 jobs:
   backend:

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -14,7 +14,11 @@ jobs:
   integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -91,7 +95,15 @@ jobs:
   integration-test-latest-mac:
     if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, vdp]
+    timeout-minutes: 20
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
+      - name: remove existing docker container
+        run: |
+          docker rm -f $(docker ps -a -q)  
+
       - name: Set up environment
         run: |
           brew install make
@@ -204,7 +216,11 @@ jobs:
   integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
         run: |
@@ -283,7 +299,15 @@ jobs:
   integration-test-release-mac:
     if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, vdp]
+    timeout-minutes: 20
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+
+      - name: remove existing docker container
+        run: |
+          docker rm -f $(docker ps -a -q)  
+
       - name: Set up environment
         run: |
           brew install make

--- a/.github/workflows/integration-test-release.yml
+++ b/.github/workflows/integration-test-release.yml
@@ -2,11 +2,6 @@ name: Integration Test (release)
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-please--branches--main
-    tags:
-      - v*
 
 jobs:
   backend:

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -2,11 +2,6 @@ name: Make All
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-please--branches--main
-    tags:
-      - v*
 
 jobs:
   make-all:


### PR DESCRIPTION
Because

- We have to create logic to cancel previous workflow if new one it triggered
- We have to set time limit for each workflow run

This commit

- set time limit to workflow run
