### PR TITLE
chore(docs): replace bad docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To shut down all running services:
 $ make down
 ```
 
-Explore our [documentation](https://www.instill.tech/docs/vdp/deployment/overview) to discover all available deployment options.
+Explore our [documentation](https://www.instill.tech/docs) to discover all available deployment options.
 
 ## Dive into the Projects
 


### PR DESCRIPTION
Because

Doc link was wrong
<img width="1470" alt="Screen Shot 2023-11-15 at 5 50 46 PM" src="https://github.com/instill-ai/vdp/assets/1466881/acb402b0-64e6-49ce-ae9b-075064e91f8c">
<img width="1470" alt="Screen Shot 2023-11-15 at 5 52 02 PM" src="https://github.com/instill-ai/vdp/assets/1466881/9adce478-2b56-468a-b075-b4bb84f19179">

This commit:
- fix doc link
