### PR TITLE
chore(helm): add rolling update strategy

### DIFF
--- a/charts/vdp/templates/controller-vdp/deployment.yaml
+++ b/charts/vdp/templates/controller-vdp/deployment.yaml
@@ -10,7 +10,11 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}
-    {{- if eq .Values.updateStrategy.type "Recreate" }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- else}}
     rollingUpdate: null
     {{- end }}
   {{- if not .Values.controllerVDP.autoscaling.enabled }}

--- a/charts/vdp/templates/pipeline-backend/deployment.yaml
+++ b/charts/vdp/templates/pipeline-backend/deployment.yaml
@@ -13,7 +13,11 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}
-    {{- if eq .Values.updateStrategy.type "Recreate" }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- else}}
     rollingUpdate: null
     {{- end }}
   {{- if not .Values.pipelineBackend.autoscaling.enabled }}

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -8,6 +8,9 @@ fullnameOverride: ""
 # Set it as "Recreate" when "RWM" for volumes isn't supported
 updateStrategy:
   type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
 # -- Logging level: debug, info, warning, error or fatal
 logLevel: info
 # -- Enable development mode


### PR DESCRIPTION
Because

- we need to add the maxSurge and maxUnavailable values into the deployment

This commit

- add rolling update strategy
