### PR TITLE
chore(helm): update path of probe endpoints

### DIFF
--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Probe to vdp services healthcheck endpoint
         run: |
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/core/v1alpha/health/mgmt
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/vdp/v1alpha/health/pipeline
+          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/core/v1beta/health/mgmt
+          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/vdp/v1beta/health/pipeline
 
       - name: Tear down Instill VDP (release)
         run: |

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -60,9 +60,9 @@ jobs:
 
       - name: Curl to vdp services healthcheck endpoint
         run: |
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/core/v1alpha/health/mgmt
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/vdp/v1alpha/health/pipeline
-          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3085/v1alpha/health/controller
+          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/core/v1beta/health/mgmt
+          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/vdp/v1beta/health/pipeline
+          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3085/v1beta/health/controller
 
       - name: Tear down Instill VDP (latest)
         run: |

--- a/charts/vdp/templates/controller-vdp/deployment.yaml
+++ b/charts/vdp/templates/controller-vdp/deployment.yaml
@@ -51,8 +51,8 @@ spec:
           args:
           - >
             while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${ETCD_HOST}:${ETCD_CLIENT_PORT}/health)" != "200" ]]; do echo waiting for etcd; sleep 1; done &&
-            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${PIPELINE_BACKEND_HOST}:${PIPELINE_BACKEND_PORT}/v1alpha/health/pipeline)" != "200" ]]; do echo waiting for pipeline-backend; sleep 1; done &&
-            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${MGMT_BACKEND_HOST}:${MGMT_BACKEND_PORT}/v1alpha/health/mgmt)" != "200" ]]; do echo waiting for mgmt-backend; sleep 1; done
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${PIPELINE_BACKEND_HOST}:${PIPELINE_BACKEND_PORT}/v1beta/health/pipeline)" != "200" ]]; do echo waiting for pipeline-backend; sleep 1; done &&
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${MGMT_BACKEND_HOST}:${MGMT_BACKEND_PORT}/v1beta/health/mgmt)" != "200" ]]; do echo waiting for mgmt-backend; sleep 1; done
           env:
             - name: PIPELINE_BACKEND_HOST
               value: "{{ template "vdp.pipelineBackend" . }}"
@@ -72,14 +72,14 @@ spec:
           imagePullPolicy: {{ .Values.controllerVDP.image.pullPolicy }}
           readinessProbe:
             httpGet:
-              path: /v1alpha/__readiness
+              path: /v1beta/__readiness
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}-private
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /v1alpha/__liveness
+              path: /v1beta/__liveness
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}-private
             initialDelaySeconds: 5

--- a/charts/vdp/templates/pipeline-backend/deployment.yaml
+++ b/charts/vdp/templates/pipeline-backend/deployment.yaml
@@ -132,7 +132,7 @@ spec:
           command: ['sh', '-c']
           args:
           - >
-            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${MGMT_BACKEND_HOST}:${MGMT_BACKEND_PORT}/v1alpha/health/mgmt)" != "200" ]]; do echo waiting for mgmt-backend; sleep 1; done
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${MGMT_BACKEND_HOST}:${MGMT_BACKEND_PORT}/v1beta/health/mgmt)" != "200" ]]; do echo waiting for mgmt-backend; sleep 1; done
           env:
             - name: MGMT_BACKEND_HOST
               value: "{{ template "core.mgmtBackend" . }}"
@@ -197,14 +197,14 @@ spec:
           imagePullPolicy: {{ .Values.pipelineBackend.image.pullPolicy }}
           readinessProbe:
             httpGet:
-              path: /v1alpha/__readiness
+              path: /v1beta/__readiness
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}-public
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /v1alpha/__liveness
+              path: /v1beta/__liveness
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}-public
             initialDelaySeconds: 5


### PR DESCRIPTION
Because

- we've upgrade the endpoints version from `v1alpha` to `v1beta`

This commit

- update path of probe endpoints
