### PR TITLE
chore(helm): update the HPA for pipeline backend containers

### DIFF
--- a/charts/vdp/templates/pipeline-backend/deployment.yaml
+++ b/charts/vdp/templates/pipeline-backend/deployment.yaml
@@ -168,9 +168,9 @@ spec:
             initialDelaySeconds: 120
             tcpSocket:
               port: rpc
-          {{- if .Values.pipelineBackend.resources }}
+          {{- if .Values.pipelineBackend.containers.pipelineBackendWorker.resources }}
           resources:
-            {{- toYaml .Values.pipelineBackend.resources | nindent 12 }}
+            {{- toYaml .Values.pipelineBackend.containers.pipelineBackendWorker.resources | nindent 12 }}
           {{- end }}
           command: [./{{ .Values.pipelineBackend.commandName.worker }}]
           env:
@@ -209,9 +209,9 @@ spec:
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}-public
             initialDelaySeconds: 5
             periodSeconds: 10
-          {{- if .Values.pipelineBackend.resources }}
+          {{- if .Values.pipelineBackend.containers.pipelineBackend.resources }}
           resources:
-            {{- toYaml .Values.pipelineBackend.resources | nindent 12 }}
+            {{- toYaml .Values.pipelineBackend.containers.pipelineBackend.resources | nindent 12 }}
           {{- end }}
           command: [./{{ .Values.pipelineBackend.commandName.main }}]
           ports:

--- a/charts/vdp/templates/pipeline-backend/hpa.yml
+++ b/charts/vdp/templates/pipeline-backend/hpa.yml
@@ -30,4 +30,22 @@ spec:
           type: AverageValue
           averageValue: {{ . }}
 {{- end }}
+{{- with .Values.pipelineBackend.autoscaling.pipelineBackendWorkerMemoryUtilization }}
+    - type: ContainerResource
+      containerResource:
+        name: memory
+        container: pipeline-backend-worker
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+{{- end }}
+{{- with .Values.pipelineBackend.autoscaling.pipelineBackendMemoryUtilization }}
+    - type: ContainerResource
+      containerResource:
+        name: memory
+        container: pipeline-backend
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+{{- end }}
 {{- end }}

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -180,6 +180,8 @@ controllerVDP:
     maxReplicas:
     targetCPUUtilizationPercentage:
     targetAverageMemoryUtilization:
+    pipelineBackendWorkerMemoryUtilization:
+    pipelineBackendMemoryUtilization:
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/charts/vdp/values.yaml
+++ b/charts/vdp/values.yaml
@@ -172,7 +172,11 @@ controllerVDP:
   podAnnotations: {}
   # -- Additional service annotations
   serviceAnnotations: {}
-  resources: {}
+  containers:
+    pipelineBackend:
+      resources: {}
+    pipelineBackendWorker:
+      resources: {}
   loopinterval: 3
   autoscaling:
     enabled: false


### PR DESCRIPTION
Because

- we need to update the HPA to scale the pod according to the requirement of pipeline backend containers

This commit

- update the HPA for pipeline backend containers
