### PR TITLE
docs(CONTRIBUTING): update new profile logic

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ COMPOSE_PROJECT_NAME=instill-vdp
 BUILD=false
 
 # docker compose profiles to selectively launch components for developing the latest codebase of the specified component.
-# the value can be all, api-gateway, mgmt, pipeline, model, controller-model, or console.
+# the value can be all, exclude-api-gateway, exclude-mgmt, exclude-pipeline, exclude-model, exclude-controller-model, or exclude-console.
 PROFILE=all
 
 # system-wise config path (all core, vdp, and model projects must use the same path)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @donch1989 @praharshjain @heiruwu @Sarthak-instill
+* @donch1989 @jvallesm @heiruwu @Sarthak-instill
 
 .github @Sarthak-instill

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,7 @@ The env variable `PROFILE` is intended to specify which service component you wa
 
 - `{service}`
 
-  When you set `PROFILE={service}`, in which `{service}` can be  `pipeline`, it means you want to develop on that particular service. The `make` command will launch the corresponding stack **WITHOUT** that service component and **WITH** all its dependencies. Given that, you can later on spin up and down the `{service}` in your dev container. Please take the [pipeline-backend](https://github.com/instill-ai/pipeline-backend#local-dev) as an example.
+  When you set `PROFILE=exclude-{service}`, in which `{service}` can be  `pipeline`, it means you want to develop on that particular service. The `make` command will launch the corresponding stack **WITHOUT** that service component and **WITH** all its dependencies. Given that, you can later on spin up and down the `{service}` in your dev container. Please take the [pipeline-backend](https://github.com/instill-ai/pipeline-backend#local-dev) as an example.
 
 ### Tear down the local dev system
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
         exclude: ^charts
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.4.0
+    rev: v0.5.1
     hooks:
       - id: golangci-lint
       - id: go-mod-tidy
@@ -23,7 +23,7 @@ repos:
         entry: bash -c 'helm lint --strict charts/**'
         language: system
   - repo: https://github.com/norwoodj/helm-docs
-    rev: v1.11.0
+    rev: v1.12.0
     hooks:
       - id: helm-docs
         args:

--- a/README.md
+++ b/README.md
@@ -41,12 +41,9 @@
 
 ## Quick Start
 
-> **Note**
-> Code in the main branch tracks under-development progress towards the next release and may not work as expected. If you are looking for a stable alpha version, please use [latest release](https://github.com/instill-ai/vdp/releases).
+**Use stable release version**
 
-Execute the following commands to start pre-built images with all the dependencies:
-
-**The stable release version**
+Execute the following commands to pull pre-built images with all the dependencies to launch:
 
 <!-- x-release-please-start-version -->
 ```bash
@@ -57,7 +54,9 @@ $ make all
 ```
 <!-- x-release-please-end -->
 
-**The latest version for development**
+**Use latest version for local development**
+
+Execute the following commands to build images with all the dependencies to launch:
 
 ```bash
 $ git clone https://github.com/instill-ai/vdp.git && cd vdp
@@ -65,6 +64,9 @@ $ git clone https://github.com/instill-ai/vdp.git && cd vdp
 # Launch all services
 $ make latest PROFILE=all
 ```
+
+> **Note**
+> Code in the main branch tracks under-development progress towards the next release and may not work as expected. If you are looking for a stable alpha version, please use [latest release](https://github.com/instill-ai/vdp/releases).
 
 🚀 That's it! Once all the services are up with health status, the UI is ready to go at http://localhost:3000. Please find the default login credentials in the [documentation](https://www.instill.tech/docs/latest/quickstart#self-hosted-instill-core).
 


### PR DESCRIPTION
Because

- we now use the `exclude-` prefix to indicate a local development target

This commit

- update documentation
- update `README.md`
- upgrade pre-commit hooks
