### PR TITLE
ci(core): fix make build-latest PROFILE

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ $ make latest PROFILE=all
 The env variable `PROFILE` is intended to specify which service component you want to develop on
 - `all`
 
-  When you set `PROFILE=all`, the whole `Instill Core` and `Instill VDP` stack will be launched, meaning you want to test the system as a whole
+  When you set `PROFILE=all`, the whole `Instill Core` and `Instill VDP` stack will be launched, meaning you want to test the system as a whole.
 
 - `{service}`
 

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -50,8 +50,9 @@ jobs:
           envFile: .env
 
       - name: Launch Instill VDP (latest)
-        run: make latest PROFILE=exclude-console EDITION=local-ce:test
-        
+        run: |
+          make latest PROFILE=exclude-console EDITION=local-ce:test
+
       - name: List all docker containers
         run: |
           docker ps -a

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ all:			## Launch all services with their up-to-date release version
 
 .PHONY: latest
 latest:			## Lunch all dependent services with their latest codebase
-	@make build-latest
+	@make build-latest PROFILE=${PROFILE}
 	@if ! docker compose ls -q | grep -q "instill-core"; then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
 		export SYSTEM_CONFIG_PATH=$(shell eval echo ${SYSTEM_CONFIG_PATH}) && \
@@ -67,11 +67,11 @@ latest:			## Lunch all dependent services with their latest codebase
 				cp /instill-ai/core/.env $${TMP_CONFIG_DIR}/.env && \
 				cp /instill-ai/core/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
 				cp -r /instill-ai/core/configs/influxdb $${TMP_CONFIG_DIR} && \
-				/bin/sh -c 'cd /instill-ai/core && make latest PROJECT=core PROFILE=$${PROFILE} EDITION=$${EDITION:=local-ce:latest} INSTILL_CORE_HOST=$${INSTILL_CORE_HOST} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}'&& \
+				/bin/sh -c 'cd /instill-ai/core && make latest PROFILE=${PROFILE} PROJECT=core EDITION=$${EDITION:=local-ce:latest} INSTILL_CORE_HOST=$${INSTILL_CORE_HOST} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}'&& \
 				rm -rf $${TMP_CONFIG_DIR}/* \
 			" && rm -rf $${TMP_CONFIG_DIR}; \
 	fi
-	@COMPOSE_PROFILES=$(PROFILE) EDITION=$${EDITION:=local-ce:latest} docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
+	@COMPOSE_PROFILES=${PROFILE} EDITION=$${EDITION:=local-ce:latest} docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
 
 .PHONY: logs
 logs:			## Tail all logs with -n 10
@@ -160,7 +160,7 @@ build-latest:				## Build latest images for all VDP components
 		--name ${CONTAINER_BUILD_NAME}-latest \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
 			PIPELINE_BACKEND_VERSION=latest \
-			docker compose -f docker-compose.build.yml build --progress plain \
+			COMPOSE_PROFILES=${PROFILE} docker compose -f docker-compose.build.yml build --progress plain \
 		"
 
 .PHONY: build-release
@@ -182,12 +182,12 @@ build-release:				## Build release images for all VDP components
 		${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_VDP_VERSION} /bin/sh -c " \
 			INSTILL_CORE_VERSION=${INSTILL_CORE_VERSION} \
 			PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_VERSION} \
-			docker compose -f docker-compose.build.yml build --progress plain \
+			COMPOSE_PROFILES=${PROFILE} docker compose -f docker-compose.build.yml build --progress plain \
 		"
 
 .PHONY: integration-test-latest
 integration-test-latest:			## Run integration test on the latest VDP
-	@make latest BUILD=true PROFILE=all EDITION=local-ce:test
+	@make latest EDITION=local-ce:test
 	@docker run --rm \
 		--network instill-network \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,15 +1,7 @@
 version: "3.9"
 
 services:
-
   pipeline_backend:
-    image: ${PIPELINE_BACKEND_IMAGE}:${PIPELINE_BACKEND_VERSION}
-    build:
-      context: ./${PIPELINE_BACKEND_HOST}
-      args:
-        SERVICE_NAME: ${PIPELINE_BACKEND_HOST}
-        GOLANG_VERSION: ${GOLANG_VERSION}
-        K6_VERSION: ${K6_VERSION}
     profiles:
       - all
       - exclude-api-gateway
@@ -17,3 +9,10 @@ services:
       - exclude-console
       - exclude-model
       - exclude-controller-model
+    image: ${PIPELINE_BACKEND_IMAGE}:${PIPELINE_BACKEND_VERSION}
+    build:
+      context: ./${PIPELINE_BACKEND_HOST}
+      args:
+        SERVICE_NAME: ${PIPELINE_BACKEND_HOST}
+        GOLANG_VERSION: ${GOLANG_VERSION}
+        K6_VERSION: ${K6_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,8 @@ services:
     depends_on:
       pipeline_backend_migrate:
         condition: service_completed_successfully
+      temporal_admin_tools_pipeline:
+        condition: service_completed_successfully
 
   socat:
     container_name: ${SOCAT_HOST}
@@ -119,8 +121,8 @@ services:
         source: /var/run/docker.sock
         target: /var/run/docker.sock
 
-  temporal_admin_tools_vdp:
-    container_name: temporal-admin-tools-vdp
+  temporal_admin_tools_pipeline:
+    container_name: temporal-admin-tools-pipeline
     image: ${TEMPORAL_ADMIN_TOOLS_IMAGE}:${TEMPORAL_ADMIN_TOOLS_VERSION}
     restart: on-failure
     environment:


### PR DESCRIPTION
Because

- the `profile` in Docker Compose is used to launch or build components when `make latest` and `make build-latest`

This commit

- fix the logic