### PR TITLE
chore(docker-compose): fix typo of `temporal_admin_tools_vdp`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
     depends_on:
       pipeline_backend_migrate:
         condition: service_completed_successfully
-      temporal_admin_tools_pipeline:
+      temporal_admin_tools_vdp:
         condition: service_completed_successfully
 
   socat:


### PR DESCRIPTION
Because

- The pipeline_backend_worker has wrong `depends_on`

This commit

- change `temporal_admin_tools_pipeline` to `temporal_admin_tools_vdp`
